### PR TITLE
Consistently use 'TypeScript' for all language tags on code blocks

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -6,7 +6,7 @@ For programs to be useful, we need to be able to work with some of the simplest 
 
 The most basic datatype is the simple true/false value, which JavaScript and TypeScript (as well as other languages) call a `boolean` value.
 
-```ts
+```TypeScript
 var isDone: boolean = false;
 ```
 
@@ -14,7 +14,7 @@ var isDone: boolean = false;
 
 As in JavaScript, all numbers in TypeScript are floating point values. These floating point numbers get the type `number`.
 
-```ts
+```TypeScript
 var height: number = 6;
 ```
 
@@ -22,7 +22,7 @@ var height: number = 6;
 
 Another fundamental part of creating programs in JavaScript for webpages and servers alike is working with textual data. As in other languages, we use the type `string` to refer to these textual datatypes. Just like JavaScript, TypeScript also uses the double quote (") or single quote (') to surround string data.
 
-```ts
+```TypeScript
 var name: string = "bob";
 name = 'smith';
 ```
@@ -31,13 +31,13 @@ name = 'smith';
 
 TypeScript, like JavaScript, allows you to work with arrays of values. Array types can be written in one of two ways. In the first, you use the type of the elements followed by `[]` to denote an array of that element type:
 
-```ts
+```TypeScript
 var list:number[] = [1, 2, 3];
 ```
 
 The second way uses a generic array type, Array<elemType>:
 
-```ts
+```TypeScript
 var list:Array<number> = [1, 2, 3];
 ```
 
@@ -45,28 +45,28 @@ var list:Array<number> = [1, 2, 3];
 
 A helpful addition to the standard set of datatypes from JavaScript is the 'enum'. Like languages like C#, an enum is a way of giving more friendly names to sets of numeric values.
 
-```ts
+```TypeScript
 enum Color {Red, Green, Blue};
 var c: Color = Color.Green;
 ```
 
 By default, enums begin numbering their members starting at 0. You can change this by manually setting the value of one its members. For example, we can start the previous example at 1 instead of 0:
 
-```ts
+```TypeScript
 enum Color {Red = 1, Green, Blue};
 var c: Color = Color.Green;
 ```
 
 Or, even manually set all the values in the enum:
 
-```ts
+```TypeScript
 enum Color {Red = 1, Green = 2, Blue = 4};
 var c: Color = Color.Green;
 ```
 
 A handy feature of enums is that you can also go from a numeric value to the name of that value in the enum. For example, if we had the value 2 but weren't sure which that mapped to in the Color enum above, we could look up the corresponding name:
 
-```ts
+```TypeScript
 enum Color {Red = 1, Green, Blue};
 var colorName: string = Color[2];
 
@@ -77,7 +77,7 @@ alert(colorName);
 
 We may need to describe the type of variables that we may not know when we are writing the application. These values may come from dynamic content, eg from the user or 3rd party library. In these cases, we want to opt-out of type-checking and let the values pass through compile-time checks. To do so, we label these with the `any` type:
 
-```ts
+```TypeScript
 var notSure: any = 4;
 notSure = "maybe a string instead";
 notSure = false; // okay, definitely a boolean
@@ -87,7 +87,7 @@ The `any` type is a powerful way to work with existing JavaScript, allowing you 
 
 The `any` type is also handy if you know some part of the type, but perhaps not all of it. For example, you may have an array but the array has a mix of different types:
 
-```ts
+```TypeScript
 var list:any[] = [1, true, "free"];
 
 list[1] = 100;
@@ -97,7 +97,7 @@ list[1] = 100;
 
 Perhaps the opposite in some ways to `any` is 'void', the absence of having any type at all. You may commonly see this as the return type of functions that do not return a value:
 
-```ts
+```TypeScript
 function warnUser(): void {
     alert("This is my warning message");
 }

--- a/pages/Classes.md
+++ b/pages/Classes.md
@@ -6,7 +6,7 @@ Traditional JavaScript focuses on functions and prototype-based inheritance as t
 
 Let's take a look at a simple class-based example:
 
-```ts
+```TypeScript
 class Greeter {
     greeting: string;
     constructor(message: string) {
@@ -32,7 +32,7 @@ In TypeScript, we can use common object-oriented patterns. Of course, one of the
 
 Let's take a look at an example:
 
-```ts
+```TypeScript
 class Animal {
     name:string;
     constructor(theName: string) { this.name = theName; }
@@ -75,7 +75,7 @@ You may have noticed in the above examples we haven't had to use the word `publi
 
 You may still mark members a private, so you control what is publicly visible outside of your class. We could have written the `Animal` class from the previous section like so:
 
-```ts
+```TypeScript
 class Animal {
     private name:string;
     constructor(theName: string) { this.name = theName; }
@@ -93,7 +93,7 @@ When comparing types that have `private` members, we treat these differently. Fo
 
 Let's look at an example to better see how this plays out in practice:
 
-```ts
+```TypeScript
 class Animal {
     private name:string;
     constructor(theName: string) { this.name = theName; }
@@ -122,7 +122,7 @@ In this example, we have an `Animal` and a `Rhino`, with `Rhino` being a subclas
 
 The keywords `public` and `private` also give you a shorthand for creating and initializing members of your class, by creating parameter properties. The properties let you can create and initialize a member in one step. Here's a further revision of the previous example. Notice how we drop `theName` altogether and just use the shortened 'private name: string' parameter on the constructor to create and initialize the `name` member.
 
-```
+```TypeScript
 class Animal {
     constructor(private name: string) { }
     move(meters: number) {
@@ -139,7 +139,7 @@ TypeScript supports getters/setters as a way of intercepting accesses to a membe
 
 Let's convert a simple class to use `get` and `set`. First, let's start with an example without getters and setters.
 
-```
+```TypeScript
 class Employee {
     fullName: string;
 }
@@ -155,7 +155,7 @@ While allowing people to randomly set fullName directly is pretty handy, this mi
 
 In this version, we check to make sure the user has a secret passcode available before we allow them to modify the employee. We do this by replacing the direct access to fullName with a `set` that will check the passcode. We add a corresponding `get` to allow the previous example to continue to work seamlessly.
 
-```
+```TypeScript
 var passcode = "secret passcode";
 
 class Employee {
@@ -190,7 +190,7 @@ Note: Accessors require you to set the compiler to output ECMAScript 5.
 
 Up to this point, we've only talked about the _instance_ members of the class, those that show up on the object when its instantiated. We can also create _static_ members of a class, those that are visible on the class itself rather than on the instances. In this example, we use `static` on the origin, as it's a general value for all grids. Each instance accesses this value through prepending the name of the class. Similarly to prepending 'this.' in front of instance accesses, here we prepend 'Grid.' in front of static accesses.
 
-```
+```TypeScript
 class Grid {
     static origin = {x: 0, y: 0};
     calculateDistanceFromOrigin(point: {x: number; y: number;}) {
@@ -214,7 +214,7 @@ alert(grid2.calculateDistanceFromOrigin({x: 10, y: 10}));
 
 When you declare a class in TypeScript, you are actually creating multiple declarations at the same time. The first is the type of the _instance_ of the class.
 
-```
+```TypeScript
 class Greeter {
     greeting: string;
     constructor(message: string) {
@@ -234,7 +234,7 @@ Here, when we say 'var greeter: Greeter', we're using Greeter as the type of ins
  
 We're also creating another value that we call the _constructor function_. This is the function that is called when we `new` up instances of the class. To see what this looks like in practice, let's take a look at the JavaScript created by the above example:
 
-```
+```TypeScript
 var Greeter = (function () {
     function Greeter(message) {
         this.greeting = message;
@@ -254,7 +254,7 @@ Here, `var Greeter` is going to be assigned the constructor function. When we ca
 
 Let's modify the example a bit to show this difference:
 
-```
+```TypeScript
 class Greeter {
     static standardGreeting = "Hello, there";
     greeting: string;
@@ -286,7 +286,7 @@ Next, we then use the class directly. Here we create a new variable called `gree
 
 As we said in the previous section, a class declaration creates two things: a type representing instances of the class and a constructor function. Because classes create types, you can use them in the same places you would be able to use interfaces.
 
-```
+```TypeScript
 class Point {
     x: number;
     y: number;

--- a/pages/Declaration Merging.md
+++ b/pages/Declaration Merging.md
@@ -23,7 +23,7 @@ Understanding what is created with each declaration will help you understand wha
 
 The simplest, and perhaps most common, type of declaration merging is interface merging. At the most basic level, the merge mechanically joins the members of both declarations into a single interface with the same name.
 
-```
+```TypeScript
 interface Box {
     height: number;
     width: number;
@@ -42,7 +42,7 @@ For function members, each function member of the same name is treated as descri
 
 That is, in the example:
 
-```
+```TypeScript
 interface Document {
     createElement(tagName: any): Element;
 }
@@ -58,7 +58,7 @@ interface Document {
 
 The two interfaces will merge to create a single declaration. otice that the elements of each group maintains the same order, just the groups themselves are merged with later overload sets coming first:
 
-```
+```TypeScript
 interface Document {
     createElement(tagName: "div"): HTMLDivElement;
     createElement(tagName: "span"): HTMLSpanElement;
@@ -78,7 +78,7 @@ To merge the namespaces, type definitions from exported interfaces declared in e
 To merge the value, at each declaration site, if a module already exists with the given name, it is further extended by taking the existing module and adding the exported members of the second module to the first.
 
 The declaration merge of 'Animals' in this example:
-```
+```TypeScript
 module Animals {
     export class Zebra { }
 }
@@ -91,7 +91,7 @@ module Animals {
 
 is equivalent to:
 
-```
+```TypeScript
 module Animals {
     export interface Legged { numberOfLegs: number; }
 
@@ -104,7 +104,7 @@ This model of module merging is a helpful starting place, but to get a more comp
 
 We can see this more clearly in this example:
 
-```
+```TypeScript
 module Animal {
     var haveMuscles = true;
 
@@ -128,7 +128,7 @@ Modules are flexible enough to also merge with other types of declarations. To d
 
 The first module merge we'll cover is merging a module with a class. This gives the user a way of describing inner classes.
 
-```
+```TypeScript
 class Album {
     label: Album.AlbumLabel;
 }
@@ -141,7 +141,7 @@ The visibility rules for merged members is the same as described in the 'Merging
 
 In addition to the pattern of inner classes, you may also be familiar with JavaScript practice of creating a function and then extending the function further by adding properties onto the function. TypeScript uses declaration merging to build up definitions like this in a type-safe way.
 
-```
+```TypeScript
 function buildLabel(name: string): string {
     return buildLabel.prefix + name + buildLabel.suffix;
 }
@@ -156,7 +156,7 @@ alert(buildLabel("Sam Smith"));
 
 Similarly, modules can be used to extend enums with static members:
 
-```
+```TypeScript
 enum Color {
     red = 1,
     green = 2,

--- a/pages/Functions.md
+++ b/pages/Functions.md
@@ -8,7 +8,7 @@ To begin, just as in JavaScript, TypeScript functions can be created both as a n
 
 To quickly recap what these two approaches look like in JavaScript:
 
-```
+```TypeScript
 // Named function
 function add(x, y) {
     return x+y;
@@ -20,7 +20,7 @@ var myAdd = function(x, y) { return x+y; };
 
 Just as in JavaScript, functions can return to variables outside of the function body. When they do so, they're said to `capture` these variables. While understanding how this works, and the trade-offs when using this technique, are outside of the scope of this article, having a firm understanding how this mechanic is an important piece of working with JavaScript and TypeScript.
 
-```
+```TypeScript
 var z = 100;
 
 function addToZ(x, y) {
@@ -34,7 +34,7 @@ function addToZ(x, y) {
 
 Let's add types to our simple examples from earlier:
 
-```
+```TypeScript
 function add(x: number, y: number): number {
     return x+y;
 }
@@ -48,14 +48,14 @@ We can add types to each of the parameters and then to the function itself to ad
 
 Now that we've typed the function, let's write the full type of the function out by looking at the each piece of the function type.
 
-```
+```TypeScript
 var myAdd: (x:number, y:number)=>number =
     function(x: number, y: number): number { return x+y; };
 ```
 
 A function's type has the same two parts: the type of the arguments and the return type. When writing out the whole function type, both parts are required. We write out the parameter types just like a parameter list, giving each parameter a name and a type. This name is just to help with readability. We could have instead written:
 
-```
+```TypeScript
 var myAdd: (baseValue:number, increment:number)=>number =
     function(x: number, y: number): number { return x+y; };
 ```
@@ -70,7 +70,7 @@ Of note, only the parameters and the return type make up the function type. Capt
 
 In playing with the example, you may notice that the TypeScript compiler can figure out the type if you have types on one side of the equation but not the other:
 
-```
+```TypeScript
 // myAdd has the full function type
 var myAdd = function(x: number, y: number): number { return x+y; };
 
@@ -85,7 +85,7 @@ This is called 'contextual typing', a form of type inference. This helps cut dow
 
 Unlike JavaScript, in TypeScript every parameter to a function is assumed to be required by the function. This doesn't mean that it isn't a `null` value, but rather, when the function is called the compiler will check that the user has provided a value for each parameter. The compiler also assumes that these parameters are the only parameters that will be passed to the function. In short, the number of parameters to the function has to match the number of parameters the function expects.
 
-```
+```TypeScript
 function buildName(firstName: string, lastName: string) {
     return firstName + " " + lastName;
 }
@@ -97,7 +97,7 @@ var result3 = buildName("Bob", "Adams");  // ah, just right
 
 In JavaScript, every parameter is considered optional, and users may leave them off as they see fit. When they do, they're assumed to be undefined. We can get this functionality in TypeScript by using the '?' beside parameters we want optional. For example, let's say we want the last name to be optional:
 
-```
+```TypeScript
 function buildName(firstName: string, lastName?: string) {
     if (lastName)
         return firstName + " " + lastName;
@@ -114,7 +114,7 @@ Optional parameters must follow required parameters. Had we wanted to make the f
 
 In TypeScript, we can also set up a value that an optional parameter will have if the user does not provide one. These are called default parameters. Let's take the previous example and default the last name to "Smith".
 
-```
+```TypeScript
 function buildName(firstName: string, lastName = "Smith") {
     return firstName + " " + lastName;
 }
@@ -128,13 +128,13 @@ Just as with optional parameters, default parameters must come after required pa
 
 Optional parameters and default parameters also share what the type looks like. Both:
 
-```
+```TypeScript
 function buildName(firstName: string, lastName?: string) {
 ```
 
 and
 
-```
+```TypeScript
 function buildName(firstName: string, lastName = "Smith") {
 ```
 
@@ -146,7 +146,7 @@ Required, optional, and default parameters all have one thing in common: they're
 
 In TypeScript, you can gather these arguments together into a variable:
 
-```
+```TypeScript
 function buildName(firstName: string, ...restOfName: string[]) {
 	return firstName + " " + restOfName.join(" ");
 }
@@ -158,7 +158,7 @@ Rest parameters are treated as a boundless number of optional parameters. You ma
 
 The ellipsis is also used in the type of the function with rest parameters:
 
-```
+```TypeScript
 function buildName(firstName: string, ...restOfName: string[]) {
 	return firstName + " " + restOfName.join(" ");
 }
@@ -174,7 +174,7 @@ In JavaScript, `this` is a variable that's set when a function is called. This m
 
 Let's look at an example:
 
-```
+```TypeScript
 var deck = {
     suits: ["hearts", "spades", "clubs", "diamonds"],
     cards: Array(52),
@@ -200,7 +200,7 @@ We can fix this by making sure the function is bound to the correct `this` befor
 
 To fix this, we switching the function expression to use the lambda syntax ( ()=>{} ) rather than the JavaScript function expression. This will automatically capture the `this` available when the function is created rather than when it is invoked:
 
-```
+```TypeScript
 var deck = {
     suits: ["hearts", "spades", "clubs", "diamonds"],
     cards: Array(52),
@@ -227,7 +227,7 @@ For more information on ways to think about `this`, you can read Yahuda Katz's [
 
 JavaScript is inherently a very dynamic language. It's not uncommon for a single JavaScript function to return different types of objects based on the shape of the arguments passed in.
 
-```
+```TypeScript
 var suits = ["hearts", "spades", "clubs", "diamonds"];
 
 function pickCard(x): any {
@@ -256,7 +256,7 @@ Here the `pickCard` function will return two different things based on what the 
 
 The answer is to supply multiple function types for the same function as a list of overloads. This list is what the compiler will use to resolve function calls. Let's create a list of overloads that describe what our `pickCard` accepts and what it returns.
 
-```
+```TypeScript
 var suits = ["hearts", "spades", "clubs", "diamonds"];
 
 function pickCard(x: {suit: string; card: number; }[]): number;

--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -10,7 +10,7 @@ To start off, let's do the "hello world" of generics: the identity function. The
 
 Without generics, we would either have to give the identity function a specific type:
 
-```
+```TypeScript
 function identity(arg: number): number {
     return arg;
 }
@@ -18,7 +18,7 @@ function identity(arg: number): number {
 
 Or, we could describe the identity function using the 'any' type:
 
-```
+```TypeScript
 function identity(arg: any): any {
     return arg;
 }
@@ -28,7 +28,7 @@ While using 'any' is certainly generic in that will accept any and all types for
 
 Instead, we need a way of capturing the type of the argument in such a way that we can also use it to denote what is being returned. Here, we will use a _type variable_, a special kind of variable that works on types rather than values.
 
-```
+```TypeScript
 function identity<T>(arg: T): T {
     return arg;
 }
@@ -40,7 +40,7 @@ We say that this version of the 'identity' function is generic, as it works over
 
 Once we've written the generic identity function, we can call it in one of two ways. The first way is to pass all of the arguments, including the type argument, to the function:
 
-```
+```TypeScript
 var output = identity<string>("myString");  // type of output will be 'string'
 ```
 
@@ -48,7 +48,7 @@ Here we explicitly set 'T' to be string as one of the arguments to the function 
 
 The second way is also perhaps the most common. Here we use /type argument inference/, that is, we want the compiler to set the value of T for us automatically based on the type of the argument we pass in:
 
-```
+```TypeScript
 var output = identity("myString");  // type of output will be 'string'
 ```
 
@@ -60,7 +60,7 @@ When you begin to use generics, you'll notice that when you create generic funct
 
 Let's take our 'identity' function from earlier:
 
-```
+```TypeScript
 function identity<T>(arg: T): T {
     return arg;
 }
@@ -68,7 +68,7 @@ function identity<T>(arg: T): T {
 
 What if want to also log the length of the argument 'arg' to the console with each call. We might be tempted to write this:
 
-```
+```TypeScript
 function loggingIdentity<T>(arg: T): T {
     console.log(arg.length);  // Error: T doesn't have .length
     return arg;
@@ -79,7 +79,7 @@ When we do, the compiler will give us an error that we're using the ".length" me
 
 Let's say that we've actually intended this function to work on arrays of T rather that T directly. Since we're working with arrays, the .length member should be available. We can describe this just like we would create arrays of other types:
 
-```
+```TypeScript
 function loggingIdentity<T>(arg: T[]): T[] {
     console.log(arg.length);  // Array has a .length, so no more error
     return arg;
@@ -90,7 +90,7 @@ You can read the type of logging Identity as "the generic function loggingIdenti
 
 We can alternatively write the sample example this way:
 
-```
+```TypeScript
 function loggingIdentity<T>(arg: Array<T>): Array<T> {
     console.log(arg.length);  // Array has a .length, so no more error
     return arg;
@@ -105,7 +105,7 @@ In previous sections, we created generic identity functions that worked over a r
 
 The type of generic functions is just like those of non-generic functions, with the type parameters listed first, similarly to function declarations:
 
-```
+```TypeScript
 function identity<T>(arg: T): T {
     return arg;
 }
@@ -115,7 +115,7 @@ var myIdentity: <T>(arg: T)=>T = identity;
 
 We could also have used a different name for the generic type parameter in the type, so long as the number of type variables and how the type variables are used line up.
 
-```
+```TypeScript
 function identity<T>(arg: T): T {
     return arg;
 }
@@ -125,7 +125,7 @@ var myIdentity: <U>(arg: U)=>U = identity;
 
 We can also write the generic type as a call signature of an object literal type:
 
-```
+```TypeScript
 function identity<T>(arg: T): T {
     return arg;
 }
@@ -135,7 +135,7 @@ var myIdentity: {<T>(arg: T): T} = identity;
 
 Which leads us to writing our first generic interface. Let's take the object literal from the previous example and move it to an interface:
 
-```
+```TypeScript
 interface GenericIdentityFn {
     <T>(arg: T): T;
 }
@@ -149,7 +149,7 @@ var myIdentity: GenericIdentityFn = identity;
 
 In a similar example, we may want to move the generic parameter to be a parameter of the whole interface. This lets us see what type(s) we're generic over (eg Dictionary<string> rather than just Dictionary). This makes the type parameter visible to all the other members of the interface.
 
-```
+```TypeScript
 interface GenericIdentityFn<T> {
     (arg: T): T;
 }
@@ -169,7 +169,7 @@ In addition to generic interfaces, we can also create generic classes. Note that
 
 A generic class has a similar shape to a generic interface. Generic classes have a generic type parameter list in angle brackets (<>) following the name of the class.
 
-```
+```TypeScript
 class GenericNumber<T> {
     zeroValue: T;
     add: (x: T, y: T) => T;
@@ -182,7 +182,7 @@ myGenericNumber.add = function(x, y) { return x + y; };
 
 This is a pretty literal use of the 'GenericNumber' class, but you may have noticed that nothing is restricting is to only use the 'number' type. We could have instead used 'string' or even more complex objects.
 
-```
+```TypeScript
 var stringNumeric = new GenericNumber<string>();
 stringNumeric.zeroValue = "";
 stringNumeric.add = function(x, y) { return x + y; };
@@ -198,7 +198,7 @@ As we covered in [Classes|Classes in TypeScript], a class has two side to its ty
 
 If you remember from an earlier example, you may sometimes want to write a generic function that works on a set of types where you have some knowledge about what capabilities that set of types will have. In our 'loggingIdentity' example, we wanted to be able access the ".length" property of 'arg', but the compiler could not prove that every type had a ".length" property, so it warns us that we can't make this assumption.
 
-```
+```TypeScript
 function loggingIdentity<T>(arg: T): T {
     console.log(arg.length);  // Error: T doesn't have .length
     return arg;
@@ -209,7 +209,7 @@ Instead of working with any and all types, we'd like to constrain this function 
 
 To do so, we'll create an interface that describes our constraint. Here, we'll create an interface that has a single ".length" property and then we'll use this interface and the {{extends}} keyword to denote our constraint:
 
-```
+```TypeScript
 interface Lengthwise {
     length: number;
 }
@@ -222,13 +222,13 @@ function loggingIdentity<T extends Lengthwise>(arg: T): T {
 
 Because the generic function is now constrained, it will no longer work over any and all types:
 
-```
+```TypeScript
 loggingIdentity(3);  // Error, number doesn't have a .length property
 ```
 
 Instead, we need to pass in values whose type has all the required properties:
 
-```
+```TypeScript
 loggingIdentity({length: 10, value: 3});
 ```
 
@@ -236,7 +236,7 @@ loggingIdentity({length: 10, value: 3});
 
 In some cases, it may be useful to declare a type parameter that is constrained by another type parameter. For example,
 
-```
+```TypeScript
 function find<T, U extends Findable<T>>(n: T, s: U) {   // errors because type parameter used in constraint
   // ...
 }
@@ -245,7 +245,7 @@ find (giraffe, myAnimals);
 
 You can achieve the pattern above by replacing the type parameter with its constraint. Rewriting the example above,
 
-```
+```TypeScript
 function find<T>(n: T, s: Findable<T>) {
   // ...
 }
@@ -258,7 +258,7 @@ _Note:_ The above is not strictly identical, as the return type of the first fun
 
 When creating factories in TypeScript using generics, it is necessary to refer to class types by their constructor functions. For example,
 
-```
+```TypeScript
 function create<T>(c: {new(): T; }): T {
     return new c();
 }
@@ -266,7 +266,7 @@ function create<T>(c: {new(): T; }): T {
 
 A more advanced example uses the prototype property to infer and constrain relationships between the constructor function and the instance side of class types.
 
-```
+```TypeScript
 class BeeKeeper {
     hasMask: boolean;
 }

--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -6,7 +6,7 @@ One of TypeScript's core principles is that type-checking focuses on the `shape`
 
 The easiest way to see how interfaces work is to start with a simple example:
 
-```
+```TypeScript
 function printLabel(labelledObj: {label: string}) {
   console.log(labelledObj.label);
 }
@@ -19,7 +19,7 @@ The type-checker checks the call to `printLabel`. The `printLabel` function has 
 
 We can write the same example again, this time using an interface to describe the requirement of having the `label` property that is a string:
 
-```
+```TypeScript
 interface LabelledValue {
   label: string;
 }
@@ -41,7 +41,7 @@ Not all properties of an interface may be required. Some exist under certain con
 
 Here's as example of this pattern:
 
-```
+```TypeScript
 interface SquareConfig {
   color?: string;
   width?: number;
@@ -65,7 +65,7 @@ Interfaces with optional properties are written similar to other interfaces, whi
 
 The advantage of optional properties is that you can describe these possibly available properties while still also catching properties that you know are not expected to be available. For example, had we mistyped the name of the property we passed to `createSquare`, we would get an error message letting us know:
 
-```
+```TypeScript
 interface SquareConfig {
   color?: string;
   width?: number;
@@ -91,7 +91,7 @@ Interfaces are capable of describing the wide range of shapes that JavaScript ob
 
 To describe a function type with an interface, we give the interface a call signature. This is like a function declaration with only the parameter list and return type given.
 
-```
+```TypeScript
 interface SearchFunc {
   (source: string, subString: string): boolean;
 }
@@ -99,7 +99,7 @@ interface SearchFunc {
 
 Once defined, we can use this function type interface like we would other interfaces. Here, we show how you can create a variable of a function type and assign it a function value of the same type.
 
-```
+```TypeScript
 var mySearch: SearchFunc;
 mySearch = function(source: string, subString: string) {
   var result = source.search(subString);
@@ -114,7 +114,7 @@ mySearch = function(source: string, subString: string) {
 
 For function types to correctly type-check, the name of the parameters do not need to match. We could have, for example, written the above example like this:
 
-```
+```TypeScript
 var mySearch: SearchFunc;
 mySearch = function(src: string, sub: string) {
   var result = src.search(sub);
@@ -133,7 +133,7 @@ Function parameters are checked one at a time, with the type in each correspondi
 
 Similarly to how we can use interfaces to describe function types, we can also describe array types. Array types have an `index` type that describes the types allowed to index the object, along with the corresponding return type for accessing the index.
 
-```
+```TypeScript
 interface StringArray {
   [index: number]: string;
 }
@@ -146,7 +146,7 @@ There are two types of supported index types: string and number. It is possible 
 
 While index signatures are a powerful way to describe the array and `dictionary` pattern, they also enforce that all properties match their return type. In this example, the property does not match the more general index, and the type-checker gives an error:
 
-```
+```TypeScript
 interface Dictionary {
   [index: string]: string;
   length: number;    // error, the type of `length` is not a subtype of the indexer
@@ -159,7 +159,7 @@ interface Dictionary {
 
 One of the most common uses of interfaces in languages like C# and Java, that of explicitly enforcing that a class meets a particular contract, is also possible in TypeScript.
 
-```
+```TypeScript
 interface ClockInterface {
     currentTime: Date;
 }
@@ -172,7 +172,7 @@ class Clock implements ClockInterface {
 
 You can also describe methods in an interface that are implemented in the class, as we do with `setTime` in the below example:
 
-```
+```TypeScript
 interface ClockInterface {
     currentTime: Date;
     setTime(d: Date);
@@ -192,7 +192,7 @@ Interfaces describe the public side of the class, rather than both the public an
 !# Difference between static/instance side of class
 When working with classes and interfaces, it helps to keep in mind that a class has _two_ types: the type of the static side and the type of the instance side. You may notice that if you create an interface with a construct signature and try to create a class that implements this interface you get an error:
 
-```
+```TypeScript
 interface ClockInterface {
     new (hour: number, minute: number);
 }
@@ -207,7 +207,7 @@ This is because when a class implements an interface, only the instance side of 
 
 Instead, you would need to work with the `static` side of the class directly. In this example, we work with the class directly:
 
-```
+```TypeScript
 interface ClockStatic {
     new (hour: number, minute: number);
 }
@@ -225,7 +225,7 @@ var newClock = new cs(7, 30);
 
 Like classes, interfaces can extend each other. This handles the task of copying the members of one interface into another, allowing you more freedom in how you separate your interfaces into reusable components.
 
-```
+```TypeScript
 interface Shape {
     color: string;
 }
@@ -241,7 +241,7 @@ square.sideLength = 10;
 
 An interface can extend multiple interfaces, creating a combination of all of the interfaces.
 
-```
+```TypeScript
 interface Shape {
     color: string;
 }
@@ -266,7 +266,7 @@ As we mentioned earlier, interfaces can describe the rich types present in real 
 
 One such example is an object that acts as both a function and an object, with additional properties:
 
-```
+```TypeScript
 interface Counter {
     (start: number): string;
     interval: number;

--- a/pages/Mixins.md
+++ b/pages/Mixins.md
@@ -6,7 +6,7 @@ Along with traditional OO hierarchies, another popular way of building up classe
 
 In the code below, we show how you can model mixins in TypeScript. After the code, we'll break down how it works.
 
-```
+```TypeScript
 // Disposable Mixin
 class Disposable {
     isDisposed: boolean;
@@ -66,7 +66,7 @@ function applyMixins(derivedCtor: any, baseCtors: any[]) {
 
 The code sample starts with the two classes that will act is our mixins. You can see each one is focused on a particular activity or capability. We'll later mix these together to form a new class from both capabilities.
 
-```
+```TypeScript
 // Disposable Mixin
 class Disposable {
     isDisposed: boolean;
@@ -90,7 +90,7 @@ class Activatable {
 
 Next, we'll create the class that will handle the combination of the two mixins. Let's look at this in more detail to see how it does this:
 
-```
+```TypeScript
 class SmartObject implements Disposable, Activatable {
 ```
 
@@ -98,7 +98,7 @@ The first thing you may notice in the above is that instead of using `extends`, 
 
 To satisfy this requirement, we create stand-in properties and their types for the members that will come from our mixins. This satisfies the compiler that these members will be available at runtime. This lets us still get the benefit of the mixins, albeit with a some bookkeeping overhead.
 
-```
+```TypeScript
 // Disposable
 isDisposed: boolean = false;
 dispose: () => void;
@@ -110,13 +110,13 @@ deactivate: () => void;
 
 Finally, we mix our mixins into the class, creating the full implementation.
 
-```
+```TypeScript
 applyMixins(SmartObject, [Disposable, Activatable])
 ```
 
 Lastly, we create a helper function that will do the mixing for us. This will run through the properties of each of the mixins and copy them over to the target of the mixins, filling out the stand-in properties with their implementations.
 
-```
+```TypeScript
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
     baseCtors.forEach(baseCtor => {
         Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {

--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -5,7 +5,7 @@ This post outlines the various ways to organize your code using modules in TypeS
 Let's start with the program we'll be using as our example throughout this page. We've written a small set of simplistic string validators, like you might use when checking a user's input on a form in a webpage or checking the format of an externally-provided data file.
 
 !!!!! Validators in a single file
-```
+```TypeScript
 interface StringValidator {
     isAcceptable(s: string): boolean;
 }
@@ -45,7 +45,7 @@ As we add more validators, we're going to want to have some kind of organization
 In this example, we've moved all the Validator-related types into a module called _Validation_. Because we want the interfaces and classes here to be visible outside the module, we preface them with _export_. Conversely, the variables _lettersRegexp_ and _numberRegexp_ are implementation details, so they are left unexported and will not be visible to code outside the module. In the test code at the bottom of the file, we now need to qualify the names of the types when used outside the module, e.g. _Validation.LettersOnlyValidator_.
 
 !!!!! Modularized Validators
-```
+```TypeScript
 module Validation {
     export interface StringValidator {
         isAcceptable(s: string): boolean;
@@ -88,7 +88,7 @@ Here, we've split our Validation module across many files. Even though the files
 
 !!! Multi-file internal modules
 !!!!! Validation.ts
-```
+```TypeScript
 module Validation {
     export interface StringValidator {
         isAcceptable(s: string): boolean;
@@ -96,7 +96,7 @@ module Validation {
 }
 ```
 !!!!! LettersOnlyValidator.ts
-```
+```TypeScript
 /// <reference path="Validation.ts" />
 module Validation {
     var lettersRegexp = /^[A-Za-z]+$/;
@@ -109,7 +109,7 @@ module Validation {
 ```
 
 !!!!! ZipCodeValidator.ts
-```
+```TypeScript
 /// <reference path="Validation.ts" />
 module Validation {
     var numberRegexp = /^[0-9]+$/;
@@ -122,7 +122,7 @@ module Validation {
 ```
 
 !!!!! Test.ts
-```
+```TypeScript
 /// <reference path="Validation.ts" />
 /// <reference path="LettersOnlyValidator.ts" />
 /// <reference path="ZipCodeValidator.ts" />
@@ -151,7 +151,7 @@ The compiler will automatically order the output file based on the reference tag
 Alternatively, we can use per-file compilation (the default) to emit one JavaScript file for each input file. If multiple JS files get produced, we'll need to use _<script>_ tags on our webpage to load each emitted file in the appropriate order, for example:
 
 !!!!! MyTestPage.html (excerpt)
-```
+```TypeScript
     <script src="Validation.js" type="text/javascript" />
     <script src="LettersOnlyValidator.js" type="text/javascript" />
     <script src="ZipCodeValidator.js" type="text/javascript" />
@@ -167,7 +167,7 @@ Below, we have converted the previous example to use external modules. Notice th
 
 The reference tags have been replaced with _import_ statements that specify the dependencies between modules. The _import_ statement has two parts: the name that the module will be known by in this file, and the require keyword that specifies the path to the required module:
 
-```
+```TypeScript
 import someMod = require('someModule');
 ```
 
@@ -180,14 +180,14 @@ tsc --module commonjs Test.ts
 When compiled, each external module will become a separate .js file. Similar to reference tags, the compiler will follow _import_ statements to compile dependent files.
 
 !!!!! Validation.ts
-```
+```TypeScript
 export interface StringValidator {
     isAcceptable(s: string): boolean;
 }
 ```
 
 !!!!! LettersOnlyValidator.ts
-```
+```TypeScript
 import validation = require('./Validation');
 var lettersRegexp = /^[A-Za-z]+$/;
 export class LettersOnlyValidator implements validation.StringValidator {
@@ -198,7 +198,7 @@ export class LettersOnlyValidator implements validation.StringValidator {
 ```
 
 !!!!! ZipCodeValidator.ts
-```
+```TypeScript
 import validation = require('./Validation');
 var numberRegexp = /^[0-9]+$/;
 export class ZipCodeValidator implements validation.StringValidator {
@@ -209,7 +209,7 @@ export class ZipCodeValidator implements validation.StringValidator {
 ```
 
 !!!!! Test.ts
-```
+```TypeScript
 import validation = require('./Validation');
 import zip = require('./ZipCodeValidator');
 import letters = require('./LettersOnlyValidator');
@@ -234,20 +234,20 @@ Depending on the module target specified during compilation, the compiler will g
 This simple example shows how the names used during importing and exporting get translated into the module loading code.
 
 !!!!! SimpleModule.ts
-```
+```TypeScript
 import m = require('mod');
 export var t = m.something + 1;
 ```
 
 !!!!! AMD / RequireJS SimpleModule.js:
-```
+```TypeScript
 define(["require", "exports", 'mod'], function(require, exports, m) {
     exports.t = m.something + 1;
 });
 ```
 
 !!!!! CommonJS / Node SimpleModule.js:
-```
+```TypeScript
 var m = require('mod');
 exports.t = m.something + 1;
 ```
@@ -260,14 +260,14 @@ The export = syntax specifies a single object that is exported from the module. 
 Below, we've simplified the Validator implementations to only export a single object from each module using the export = syntax. This simplifies the consumption code – instead of referring to 'zip.ZipCodeValidator', we can simply refer to 'zipValidator'.
 
 !!!!! Validation.ts
-```
+```TypeScript
 export interface StringValidator {
     isAcceptable(s: string): boolean;
 }
 ```
 
 !!!!! LettersOnlyValidator.ts
-```
+```TypeScript
 import validation = require('./Validation');
 var lettersRegexp = /^[A-Za-z]+$/;
 class LettersOnlyValidator implements validation.StringValidator {
@@ -279,7 +279,7 @@ export = LettersOnlyValidator;
 ```
 
 !!!!! ZipCodeValidator.ts
-```
+```TypeScript
 import validation = require('./Validation');
 var numberRegexp = /^[0-9]+$/;
 class ZipCodeValidator implements validation.StringValidator {
@@ -291,7 +291,7 @@ export = ZipCodeValidator;
 ```
 
 !!!!! Test.ts
-```
+```TypeScript
 import validation = require('./Validation');
 import zipValidator = require('./ZipCodeValidator');
 import lettersValidator = require('./LettersOnlyValidator');
@@ -314,7 +314,7 @@ strings.forEach(s => {
 Another way that you can simplify working with either kind of module is to use _import q = x.y.z_ to create shorter names for commonly-used objects. Not to be confused with the _import x = require('name')_ syntax used to load external modules, this syntax simply creates an alias for the specified symbol. You can use these sorts of imports (commonly referred to as aliases) for any kind of identifier, including objects created from external module imports.
 
 !!!!! Basic Aliasing
-```
+```TypeScript
 module Shapes {
     export module Polygons {
         export class Triangle { }
@@ -338,7 +338,7 @@ The core idea of the pattern is that the _import id = require('...')_ statement 
 To maintain type safety, we can use the _typeof_ keyword. The _typeof_ keyword, when used in a type position, produces the type of a value, in this case the type of the external module.
 
 !!!!! Dynamic Module Loading in node.js
-```
+```TypeScript
 declare var require;
 import Zip = require('./ZipCodeValidator');
 if (needZipValidation) {
@@ -348,7 +348,7 @@ if (needZipValidation) {
 ```
 
 !!!!! Sample: Dynamic Module Loading in require.js
-```
+```TypeScript
 declare var require;
 import Zip = require('./ZipCodeValidator');
 if (needZipValidation) {
@@ -365,7 +365,7 @@ To describe the shape of libraries not written in TypeScript, we need to declare
 The popular library D3 defines its functionality in a global object called 'D3'. Because this library is loaded through a _script_ tag (instead of a module loader), its declaration uses internal modules to define its shape. For the TypeScript compiler to see this shape, we use an ambient internal module declaration. For example:
 
 !!!!! D3.d.ts (simplified excerpt)
-```
+```TypeScript
 declare module D3 {
     export interface Selectors {
         select: {
@@ -391,7 +391,7 @@ declare var d3: D3.Base;
 In node.js, most tasks are accomplished by loading one or more modules. We could define each module in its own .d.ts file with top-level export declarations, but it's more convenient to write them as one larger .d.ts file. To do so, we use the quoted name of the module, which will be available to a later import. For example:
 
 !!!!! node.d.ts (simplified excerpt)
-```
+```TypeScript
 declare module "url" {
     export interface Url {
         protocol?: string;
@@ -411,7 +411,7 @@ declare module "path" {
 
 Now we can _/// <reference>_ node.d.ts and then load the modules using e.g. _import url = require('url');_.
 
-```
+```TypeScript
 ///<reference path="node.d.ts"/>
 import url = require("url");
 var myUrl = url.parse("http://www.typescriptlang.org");
@@ -431,7 +431,7 @@ The second is by finding a .d.ts file, similar to above, except that instead of 
 The final way is by seeing an "ambient external module declaration", where we 'declare' a module with a matching quoted name.
 
 !!!!! myModules.d.ts
-```
+```TypeScript
 // In a .d.ts file or .ts file that is not an external module:
 declare module "SomeModule" {
     export function fn(): string;
@@ -439,7 +439,7 @@ declare module "SomeModule" {
 ```
 
 !!!!! myOtherModule.ts
-```
+```TypeScript
 /// <reference path="myModules.d.ts" />
 import m = require("SomeModule");
 ```
@@ -450,7 +450,7 @@ The reference tag here allows us to locate the declaration file that contains th
 If you're converting a program from internal modules to external modules, it can be easy to end up with a file that looks like this:
 
 !!!!! shapes.ts
-```
+```TypeScript
 export module Shapes {
     export class Triangle { /* ... */ }
     export class Square { /* ... */ }
@@ -459,7 +459,7 @@ export module Shapes {
 
 The top-level module here _Shapes_ wraps up _Triangle_ and _Square_ for no reason. This is confusing and annoying for consumers of your module:
 !!!!! shapeConsumer.ts
-```
+```TypeScript
 import shapes = require('./shapes');
 var t = new shapes.Shapes.Triangle(); // shapes.Shapes?
 ```
@@ -470,13 +470,13 @@ To reiterate why you shouldn't try to namespace your external module contents, t
 
 Revised Example:
 !!!!! shapes.ts
-```
+```TypeScript
 export class Triangle { /* ... */ }
 export class Square { /* ... */ }
 ```
 
 !!!!! shapeConsumer.ts
-```
+```TypeScript
 import shapes = require('./shapes');
 var t = new shapes.Triangle();
 ```

--- a/pages/Type Compatibility.md
+++ b/pages/Type Compatibility.md
@@ -2,7 +2,7 @@
 
 Type compatibility in TypeScript is based on structural subtyping. Structural typing is a way of relating types based solely on their members. This is in contrast with nominal typing. Consider the following code:
 
-```
+```TypeScript
 interface Named {
     name: string;
 }
@@ -26,7 +26,7 @@ TypeScript’s type system allows certain operations that can’t be known at compil
 # Starting out
 The basic rule for TypeScript’s structural type system is that x is compatible with y if y has at least the same members as x. For example:
 
-```
+```TypeScript
 interface Named {
     name: string;
 }
@@ -41,7 +41,7 @@ To check whether y can be assigned to x, the compiler checks each property of x 
 
 The same rule for assignment is used when checking function call arguments:
 
-```
+```TypeScript
 function greet(n: Named) {
     alert('Hello, ' + n.name);
 }
@@ -55,7 +55,7 @@ This comparison process proceeds recursively, exploring the type of each member 
 # Comparing two functions
 While comparing primitive types and object types is relatively straightforward, the question of what kinds of functions should be considered compatible. Let’s start with a basic example of two functions that differ only in their argument lists:
 
-```
+```TypeScript
 var x = (a: number) => 0;
 var y = (b: number, s: string) => 0;
 
@@ -69,7 +69,7 @@ The second assignment is an error, because y has a required second parameter tha
 
 You may be wondering why we allow ‘discarding’ parameters like in the example y = x. The reason is that assignment is allowed is that ignoring extra function parameters is actually quite common in JavaScript. For example, Array#forEach provides three arguments to the callback function: the array element, its index, and the containing array. Nevertheless, it’s very useful to provide a callback that only uses the first argument:
 
-```
+```TypeScript
 var items = [1, 2, 3];
 
 // Don't force these extra arguments
@@ -81,7 +81,7 @@ items.forEach((item) => console.log(item));
 
 Now let’s look at how return types are treated, using two functions that differ only by their return type:
 
-```
+```TypeScript
 var x = () => ({name: 'Alice'});
 var y = () => ({name: 'Alice', location: 'Seattle'});
 
@@ -94,7 +94,7 @@ The type system enforces that the source function’s return type be a subtype of 
 ## Function Argument Bivariance
 When comparing the types of function parameters, assignment succeeds if either the source parameter is assignable to the target parameter, or vice versa. This is unsound because a caller might end up being given a function that takes a more specialized type, but invokes the function with a less specialized type. In practice, this sort of error is rare, and allowing this enables many common JavaScript patterns. A brief example:
 
-```
+```TypeScript
 enum EventType { Mouse, Keyboard }
 
 interface Event { timestamp: number; }
@@ -125,7 +125,7 @@ This is unsound from a type system perspective, but from a runtime point of view
 
 The motivating example is the common pattern of a function that takes a callback and invokes it with some predictable (to the programmer) but unknown (to the type system) number of arguments:
 
-```
+```TypeScript
 function invokeLater(args: any[], callback: (...args: any[]) => void) {
     /* ... Invoke callback with 'args' ... */
 }
@@ -145,7 +145,7 @@ When a function has overloads, each overload in the source type must be matched 
 
 Enums are compatible with numbers, and numbers are compatible with enums. Enum values from different enum types are considered incompatible. For example,
 
-```
+```TypeScript
 enum Status { Ready, Waiting };
 enum Color { Red, Blue, Green };
 
@@ -157,7 +157,7 @@ status = Color.Green;  //error
 
 Classes work similarly to object literal types and interfaces with one exception: they have both a static and an instance type. When comparing two objects of a class type, only members of the instance are compared. Static members and constructors do not affect compatibility.
 
-```
+```TypeScript
 class Animal {
     feet: number;
     constructor(name: string, numFeet: number) { }
@@ -183,7 +183,7 @@ Private members in a class affect their compatibility. When an instance of a cla
 
 Because TypeScript is a structural type system, type parameters only affect the resulting type when consumed as part of the type of a member. For example,
 
-```
+```TypeScript
 interface Empty<T> {
 }
 var x: Empty<number>;
@@ -194,7 +194,7 @@ x = y;  // okay, y matches structure of x
 
 In the above, x and y are compatible because their structures do not use the type argument in a differentiating way. Changing this example by adding a member to Empty<T> shows how this works:
 
-```
+```TypeScript
 interface NotEmpty<T> {
     data: T;
 }
@@ -210,7 +210,7 @@ For generic types that do not have their type arguments specified, compatibility
 
 For example,
 
-```
+```TypeScript
 var identity = function<T>(x: T): T {
     // ...
 }

--- a/pages/Type Inference.md
+++ b/pages/Type Inference.md
@@ -6,7 +6,7 @@ In this section, we will cover type inference in TypeScript. Namely, we'll discu
 
 In TypeScript, there are several places where type inference is used to provide type information when there is no explicit type annotation. For example, in this code
 
-```
+```TypeScript
 var x = 3;
 ```
 
@@ -18,7 +18,7 @@ In most cases, type inference is straightforward. In the following sections, we'
 
 When a type inference is made from several expressions, the types of those expressions are used to calculate a "best common type". For example,
 
-```
+```TypeScript
 var x = [0, 1, null];
 ```
 
@@ -26,13 +26,13 @@ To infer the type of `x` in the example above, we must consider the type of each
 
 Because the best common type has to be chosen from the provided candidate types, there are some cases where types share a common structure, but no one type is the super type of all candidate types. For example:
 
-```
+```TypeScript
 var zoo = [new Rhino(), new Elephant(), new Snake()];
 ```
 
 Ideally, we may want `zoo` to be inferred as an {{Animal[]}}, but because there is no object that is strictly of type `Animal` in the array, we make no inference about the array element type. To correct this, instead explicitly provide the type when no one type is a super type of all other candidates:
 
-```
+```TypeScript
 var zoo: Animal[] = [new Rhino(), new Elephant(), new Snake()];
 ```
 
@@ -42,7 +42,7 @@ When no best common type is found, the resulting inference is the empty object t
 
 Type inference also works in "the other direction" in some cases in TypeScript. This is known as "contextual typing". Contextual typing occurs when the type of an expression is implied by its location. For example:
 
-```
+```TypeScript
 window.onmousedown = function(mouseEvent) {
     console.log(mouseEvent.buton);  //<- Error
 };
@@ -52,7 +52,7 @@ For the code above to give the type error, the TypeScript type checker used the 
 
 If the contextually typed expression contains explicit type information, the contextual type is ignored. Had we written the above example:
 
-```
+```TypeScript
 window.onmousedown = function(mouseEvent: any) {
     console.log(mouseEvent.buton);  //<- Now, no error is given
 };
@@ -62,7 +62,7 @@ The function expression with an explicit type annotation on the parameter will o
 
 Contextual typing applies in many cases. Common cases include arguments to function calls, right hand sides of assignments, type assertions, members of object and array literals, and return statements. The contextual type also acts as a candidate type in best common type. For example:
 
-```
+```TypeScript
 function createZoo(): Animal[] {
     return [new Rhino(), new Elephant(), new Snake()];
 }

--- a/pages/Writing Definition Files.md
+++ b/pages/Writing Definition Files.md
@@ -21,20 +21,20 @@ When writing definition files, it's important to remember TypeScript's rules for
 
 *Anonymously-typed var*
 
-```
+```TypeScript
 declare var MyPoint: { x: number; y: number; };
 ```
 
 *Interfaced-typed var*
 
-```
+```TypeScript
 interface SomePoint { x: number; y: number; }
 declare var MyPoint: SomePoint;
 ```
 
 From a consumption side these declarations are identical, but the type {{SomePoint}} can be extended through interface merging:
 
-```
+```TypeScript
 interface SomePoint { z: number; }
 MyPoint.z = 4; // OK
 ```
@@ -51,7 +51,7 @@ As an example, the following two declarations are nearly equivalent from a consu
 
 *Standard*
 
-```
+```TypeScript
 class A {
     static st: string;
     inst: number;
@@ -61,7 +61,7 @@ class A {
 
 *Decomposed*
 
-```
+```TypeScript
 interface A_Static {
     new(m: any): A_Instance;
     st: string;
@@ -89,7 +89,7 @@ Let's jump in to the examples section. For each example, sample _usage_ of the l
 ## Options Objects
 
 *Usage*
-```
+```TypeScript
 animalFactory.create("dog");
 animalFactory.create("giraffe", { name: "ronald" });
 animalFactory.create("panda", { name: "bob", height: 400 });
@@ -98,7 +98,7 @@ animalFactory.create("cat", { height: 32 });
 ```
 
 *Typing*
-```
+```TypeScript
 module animalFactory {
     interface AnimalOptions {
         name: string;
@@ -111,13 +111,13 @@ module animalFactory {
 
 ## Functions with Properties
 *Usage*
-```
+```TypeScript
 zooKeeper.workSchedule = "morning";
 zooKeeper(giraffeCage);
 ```
 
 *Typing*
-```
+```TypeScript
 // Note: Function must precede module
 function zooKeeper(cage: AnimalCage);
 module zooKeeper {
@@ -127,7 +127,7 @@ module zooKeeper {
 
 ## New + callable methods
 *Usage*
-```
+```TypeScript
 var w = widget(32, 16);
 var y = new widget("sprocket");
 // w and y are both widgets
@@ -136,7 +136,7 @@ y.sprock();
 ```
 
 *Typing*
-```
+```TypeScript
 interface Widget {
     sprock(): void;
 }
@@ -151,7 +151,7 @@ declare var widget: WidgetFactory;
 
 ## Global / External-agnostic Libraries
 *Usage*
-```
+```TypeScript
 // Either
 import x = require('zoo');
 x.open();
@@ -160,7 +160,7 @@ zoo.open();
 ```
 
 *Typing*
-```
+```TypeScript
 module zoo {
   function open(): void;
 }
@@ -172,7 +172,7 @@ declare module "zoo" {
 
 ## Single Complex Object in External Modules
 *Usage*
-```
+```TypeScript
 // Super-chainable library for eagles
 import eagle = require('./eagle');
 // Call directly
@@ -184,7 +184,7 @@ eagle.favorite = 'golden';
 ```
 
 *Typing*
-```
+```TypeScript
 // Note: can use any name here, but has to be the same throughout this file
 declare function eagle(name: string): eagle;
 declare module eagle {
@@ -200,12 +200,12 @@ export = eagle;
 
 ## Callbacks
 *Usage*
-```
+```TypeScript
 addLater(3, 4, (x) => console.log('x = ' + x));
 ```
 
 *Typing*
-```
+```TypeScript
 // Note: 'void' return type is preferred here
 function addLater(x: number, y: number, (sum: number) => void): void;
 ```


### PR DESCRIPTION
Addresses the tagging issues in #8.