### PR TITLE
Remove extra word

### DIFF
--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -19,7 +19,7 @@ printLabel(myObj);
 
 The type-checker checks the call to `printLabel`.
 The `printLabel` function has a single parameter that requires that the object passed in has a property called `label` of type string.
-Notice that our object actually has more properties than this, but the compiler only checks to that *at least* the ones required are present and match the types required.
+Notice that our object actually has more properties than this, but the compiler only checks that *at least* the ones required are present and match the types required.
 
 We can write the same example again, this time using an interface to describe the requirement of having the `label` property that is a string:
 


### PR DESCRIPTION
I removed the unneeded 'to' from line 22. 
This changes 'the compiler only checks **to that**..." to "the compiler only checks **that**..."

The original sentence in question: 
> Notice that our object actually has more properties than this, but the compiler only checks **to that**
> *at  least* the ones required are present and match the types required."