### PR TITLE
Fix typo: use minute instead of number

### DIFF
--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -259,7 +259,7 @@ interface ClockInterface {
 }
 
 function createClock(ctor: ClockConstructor, hour: number, minute: number): ClockInterface {
-    return new ctor(hour, number);
+    return new ctor(hour, minute);
 }
 
 class DigitalClock implements ClockInterface {


### PR DESCRIPTION
One typo in Interfaces.md. It should be 
```ts
function createClock(ctor: ClockConstructor, hour: number, minute: number): ClockInterface {
    return new ctor(hour, minute);
}
```
Not
```ts
function createClock(ctor: ClockConstructor, hour: number, minute: number): ClockInterface {
    return new ctor(hour, number);
}
```