### PR TITLE
add missing declare

### DIFF
--- a/pages/Writing Definition Files.md
+++ b/pages/Writing Definition Files.md
@@ -187,7 +187,7 @@ zoo.open();
 #### Typing
 
 ```ts
-namespace zoo {
+declare namespace zoo {
   function open(): void;
 }
 


### PR DESCRIPTION
would not compile otherwise:
"A 'declare' modifier is required for a top level declaration in a .d.ts file"