### PR TITLE
Adding consistency with examples used elsewhere in docs and to render nicer in HTML

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -523,7 +523,7 @@ If a module's primary purpose is to house one specific export, then you should c
 This makes both importing and actually using the import a little easier.
 For example:
 
-#### MyClass.ts
+##### MyClass.ts
 
 ```ts
 export default class SomeType {
@@ -531,13 +531,13 @@ export default class SomeType {
 }
 ```
 
-#### MyFunc.ts
+##### MyFunc.ts
 
 ```ts
 export default function getThing() { return 'thing'; }
 ```
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import t from "./MyClass";
@@ -550,7 +550,7 @@ This is optimal for consumers. They can name your type whatever they want (`t` i
 
 ### If you're exporting multiple objects, put them all at top-level
 
-#### MyThings.ts
+##### MyThings.ts
 
 ```ts
 export class SomeType { /* ... */ }
@@ -561,7 +561,7 @@ Conversly when importing:
 
 ### Explicitlly list imported names
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import { SomeType, SomeFunc } from "./MyThings";
@@ -571,7 +571,7 @@ let y = someFunc();
 
 ### Use the namespace import pattern if you're importing a large number of things
 
-#### MyLargeModule.ts
+##### MyLargeModule.ts
 
 ```ts
 export class Dog { ... }
@@ -580,7 +580,7 @@ export class Tree { ... }
 export class Flower { ... }
 ```
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import * as myLargeModule from "./MyLargeModule.ts";
@@ -597,7 +597,7 @@ The recommended solution is to *not* mutate the original object, but rather expo
 Consider a simple calculator implementation defined in module `Calculator.ts`.
 The module also exports a helper function to test the calculator functionality by passing a list of input strings and writing the result at the end.
 
-#### Calculator.ts
+##### Calculator.ts
 
 ```ts
 export class Calculator {
@@ -675,7 +675,7 @@ export function test(c: Calculator, input: string) {
 
 Here is a simple test for the calculator using the exposed `test` function.
 
-#### TestCalculator.ts
+##### TestCalculator.ts
 
 ```ts
 import { Calculator, test } from "./Calculator";
@@ -687,7 +687,7 @@ test(c, "1+2*33/11="); // prints 9
 
 Now to extend this to add support for input with numbers in bases other than 10, let's create `ProgrammerCalculator.ts`
 
-#### ProgrammerCalculator.ts
+##### ProgrammerCalculator.ts
 
 ```ts
 import { Calculator } from "./Calculator";
@@ -720,7 +720,7 @@ The new module `ProgrammerCalculator` exports an API shape similar to that of th
 Here is a test for our ProgrammerCalculator class:
 
 
-#### TestProgrammerCalculator.ts
+##### TestProgrammerCalculator.ts
 
 ```ts
 import { Calculator, test } from "./ProgrammerCalculator";

--- a/pages/Namespaces and Modules.md
+++ b/pages/Namespaces and Modules.md
@@ -48,21 +48,21 @@ The compiler will try to find a `.ts`, `.tsx`, and then a `.d.ts` with the appro
 If a specific file could not be found, then the compiler will look for an *ambient module declaration*.
 Recall that these need to be declared in a `.d.ts` file.
 
-* `myModules.d.ts`
+##### myModules.d.ts
 
-    ```ts
-    // In a .d.ts file or .ts file that is not a module:
-    declare module "SomeModule" {
-        export function fn(): string;
-    }
-    ```
+```ts
+// In a .d.ts file or .ts file that is not a module:
+declare module "SomeModule" {
+    export function fn(): string;
+}
+```
 
-* `myOtherModule.ts`
+##### myOtherModule.ts
 
-    ```ts
-    /// <reference path="myModules.d.ts" />
-    import * as m from "SomeModule";
-    ```
+```ts
+/// <reference path="myModules.d.ts" />
+import * as m from "SomeModule";
+```
 
 The reference tag here allows us to locate the declaration file that contains the declaration for the ambient module.
 This is how the `node.d.ts` file that several of the TypeScript samples use is consumed.
@@ -71,24 +71,24 @@ This is how the `node.d.ts` file that several of the TypeScript samples use is c
 
 If you're converting a program from namespaces to modules, it can be easy to end up with a file that looks like this:
 
-* `shapes.ts`
+##### shapes.ts
 
-    ```ts
-    export namespace Shapes {
-        export class Triangle { /* ... */ }
-        export class Square { /* ... */ }
-    }
-    ```
+```ts
+export namespace Shapes {
+    export class Triangle { /* ... */ }
+    export class Square { /* ... */ }
+}
+```
 
 The top-level module here `Shapes` wraps up `Triangle` and `Square` for no reason.
 This is confusing and annoying for consumers of your module:
 
-* `shapeConsumer.ts`
+##### shapeConsumer.ts
 
-    ```ts
-    import * as shapes from "./shapes";
-    let t = new shapes.Shapes.Triangle(); // shapes.Shapes?
-    ```
+```ts
+import * as shapes from "./shapes";
+let t = new shapes.Shapes.Triangle(); // shapes.Shapes?
+```
 
 A key feature of modules in TypeScript is that two different modules will never contribute names to the same scope.
 Because the consumer of a module decides what name to assign it, there's no need to proactively wrap up the exported symbols in a namespace.
@@ -98,19 +98,19 @@ Because the module file itself is already a logical grouping, and its top-level 
 
 Here's a revised example:
 
-* `shapes.ts`
+##### shapes.ts
 
-    ```ts
-    export class Triangle { /* ... */ }
-    export class Square { /* ... */ }
-    ```
+```ts
+export class Triangle { /* ... */ }
+export class Square { /* ... */ }
+```
 
-* `shapeConsumer.ts`
+##### shapeConsumer.ts
 
-    ```ts
-    import * as shapes from "./shapes";
-    let t = new shapes.Triangle();
-    ```
+```ts
+import * as shapes from "./shapes";
+let t = new shapes.Triangle();
+```
 
 ## Trade-offs of Modules
 

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -15,54 +15,54 @@ When input files are specified on the command line, `tsconfig.json` files are ig
 
 Example `tsconfig.json` files:
 
-* Using the `"files"` property
+##### Using the `"files"` property
 
-    ```json
-    {
-        "compilerOptions": {
-            "module": "commonjs",
-            "noImplicitAny": true,
-            "removeComments": true,
-            "preserveConstEnums": true,
-            "out": "../../built/local/tsc.js",
-            "sourceMap": true
-        },
-        "files": [
-            "core.ts",
-            "sys.ts",
-            "types.ts",
-            "scanner.ts",
-            "parser.ts",
-            "utilities.ts",
-            "binder.ts",
-            "checker.ts",
-            "emitter.ts",
-            "program.ts",
-            "commandLineParser.ts",
-            "tsc.ts",
-            "diagnosticInformationMap.generated.ts"
-        ]
-    }
-    ```
+```json
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "out": "../../built/local/tsc.js",
+        "sourceMap": true
+    },
+    "files": [
+        "core.ts",
+        "sys.ts",
+        "types.ts",
+        "scanner.ts",
+        "parser.ts",
+        "utilities.ts",
+        "binder.ts",
+        "checker.ts",
+        "emitter.ts",
+        "program.ts",
+        "commandLineParser.ts",
+        "tsc.ts",
+        "diagnosticInformationMap.generated.ts"
+    ]
+}
+```
 
-* Using the `"exclude"` property
+##### Using the `"exclude"` property
 
-    ```json
-    {
-        "compilerOptions": {
-            "module": "commonjs",
-            "noImplicitAny": true,
-            "removeComments": true,
-            "preserveConstEnums": true,
-            "out": "../../built/local/tsc.js",
-            "sourceMap": true
-        },
-        "exclude": [
-            "node_modules",
-            "wwwroot"
-        ]
-    }
-    ```
+```json
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "out": "../../built/local/tsc.js",
+        "sourceMap": true
+    },
+    "exclude": [
+        "node_modules",
+        "wwwroot"
+    ]
+}
+```
 
 ## Details
 


### PR DESCRIPTION
I changed all example code sections I could find to have their title set at headline level 5, so that they don't draw a lot of attention to people scanning the page quickly.  Additionally for filenames, I changed them to not have code elements, since filenames are not code per se.

I also removed unordered lists that were causing the markdown renderer on the website to make code fences not render as code blocks in HTML.