### PR TITLE
Indent code blocks in lists properly

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -1,8 +1,10 @@
 var markdownlint = require("markdownlint");
 var glob = require("glob");
+var fs = require("fs");
 
+var inputFiles = glob.sync("**/*.md", { ignore: "node_modules/**/*" });
 var options = {
-  files: glob.sync("**/*.md", { ignore: "node_modules/**/*" }),
+  files: inputFiles,
   config: {
     MD001: false, // Header levels should only increment by one level at a time
     MD002: false, // First header should be a h1 header
@@ -43,7 +45,12 @@ var options = {
     MD041: false, // First line in file should be a top level header
   }
 };
- 
+
+var fencedCodeBlockInUnorderedListRegEx = /^(\s+\*\s+)\S.+\r?\n(\s*)/m;
+var carriageReturn = 0x0D;
+var lineFeed = 0x0A;
+
+
 var result = markdownlint.sync(options);
 console.log(result.toString());
 
@@ -56,4 +63,60 @@ Object.keys(result).forEach(function (file) {
     });
 });
 
+inputFiles.forEach(function(fileName) {
+    var text = fs.readFileSync(fileName, "utf8")
+    exitCode += checkForImproperlyIndentedFencedCodeBlocks(fileName, text);
+})
+
 process.exit(exitCode);
+
+/**
+ * @param {string} fileName
+ * @param {string} text
+ */
+function checkForImproperlyIndentedFencedCodeBlocks(fileName, text) {
+    var lines = text.split(/\r?\n/g);
+    var numErrors = 0;
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var codeBlockMatch = line.match(/^(\s*)```\S+/);
+
+        if (codeBlockMatch) {
+            var startingColumn = codeBlockMatch[1].length;
+            if (startingColumn === 0 || startingColumn === getCorrectStartingColumnForLine(lines, i)) {
+                continue;
+            }
+
+            numErrors++;
+            console.log(fileName, ": ",
+                        i + 1, ": A fenced code block following a list item must be indented to the first non-whitespace character of the list item.")
+        }
+    }
+
+    return numErrors;
+}
+
+/**
+ * @param {string[]} line
+ * @param {number} lineIndex
+ */
+function getCorrectStartingColumnForLine(lines, lineIndex) {
+    for (var i = lineIndex - 1; i >= 0; i--) {
+        var line = lines[i];
+
+        if (line.length === 0) {
+            continue;
+        }
+
+        var m;
+        if (m = line.match(/^\s*([\*\-]|(\d+\.))\s*/)) {
+            return m[0].length;
+        }
+        if (m = line.match(/^(\s*)/)) {
+            return m[0].length;
+        }
+    }
+
+    return 0;
+}

--- a/lint.js
+++ b/lint.js
@@ -46,11 +46,6 @@ var options = {
   }
 };
 
-var fencedCodeBlockInUnorderedListRegEx = /^(\s+\*\s+)\S.+\r?\n(\s*)/m;
-var carriageReturn = 0x0D;
-var lineFeed = 0x0A;
-
-
 var result = markdownlint.sync(options);
 console.log(result.toString());
 

--- a/pages/Namespaces and Modules.md
+++ b/pages/Namespaces and Modules.md
@@ -50,19 +50,19 @@ Recall that these need to be declared in a `.d.ts` file.
 
 * `myModules.d.ts`
 
-    ```ts
-    // In a .d.ts file or .ts file that is not a module:
-    declare module "SomeModule" {
-        export function fn(): string;
-    }
-    ```
+  ```ts
+  // In a .d.ts file or .ts file that is not a module:
+  declare module "SomeModule" {
+      export function fn(): string;
+  }
+  ```
 
 * `myOtherModule.ts`
 
-    ```ts
-    /// <reference path="myModules.d.ts" />
-    import * as m from "SomeModule";
-    ```
+  ```ts
+  /// <reference path="myModules.d.ts" />
+  import * as m from "SomeModule";
+  ```
 
 The reference tag here allows us to locate the declaration file that contains the declaration for the ambient module.
 This is how the `node.d.ts` file that several of the TypeScript samples use is consumed.
@@ -73,22 +73,22 @@ If you're converting a program from namespaces to modules, it can be easy to end
 
 * `shapes.ts`
 
-    ```ts
-    export namespace Shapes {
-        export class Triangle { /* ... */ }
-        export class Square { /* ... */ }
-    }
-    ```
+  ```ts
+  export namespace Shapes {
+      export class Triangle { /* ... */ }
+      export class Square { /* ... */ }
+  }
+  ```
 
 The top-level module here `Shapes` wraps up `Triangle` and `Square` for no reason.
 This is confusing and annoying for consumers of your module:
 
 * `shapeConsumer.ts`
 
-    ```ts
-    import * as shapes from "./shapes";
-    let t = new shapes.Shapes.Triangle(); // shapes.Shapes?
-    ```
+  ```ts
+  import * as shapes from "./shapes";
+  let t = new shapes.Shapes.Triangle(); // shapes.Shapes?
+  ```
 
 A key feature of modules in TypeScript is that two different modules will never contribute names to the same scope.
 Because the consumer of a module decides what name to assign it, there's no need to proactively wrap up the exported symbols in a namespace.
@@ -100,17 +100,17 @@ Here's a revised example:
 
 * `shapes.ts`
 
-    ```ts
-    export class Triangle { /* ... */ }
-    export class Square { /* ... */ }
-    ```
+  ```ts
+  export class Triangle { /* ... */ }
+  export class Square { /* ... */ }
+  ```
 
 * `shapeConsumer.ts`
 
-    ```ts
-    import * as shapes from "./shapes";
-    let t = new shapes.Triangle();
-    ```
+  ```ts
+  import * as shapes from "./shapes";
+  let t = new shapes.Triangle();
+  ```
 
 ## Trade-offs of Modules
 

--- a/pages/Typings for NPM Packages.md
+++ b/pages/Typings for NPM Packages.md
@@ -4,15 +4,15 @@ The compiler will try to discover typings for module `"foo"` using the following
 
 1. Try to load the `package.json` file located in the appropriate package folder (`node_modules/foo/`). If present,read the path to the typings file described in the `"typings"` field. For example, in the following `package.json`, the compiler will resolve the typings at `node_modules/foo/lib/foo.d.ts`
 
-    ```JSON
-    {
-        "name": "foo",
-        "author": "Vandelay Industries",
-        "version": "1.0.0",
-        "main": "./lib/foo.js",
-        "typings": "./lib/foo.d.ts"
-    }
-    ```
+   ```JSON
+   {
+       "name": "foo",
+       "author": "Vandelay Industries",
+       "version": "1.0.0",
+       "main": "./lib/foo.js",
+       "typings": "./lib/foo.d.ts"
+   }
+   ```
 
 2. Try to load a file named `index.d.ts` located in the package folder (`node_modules/foo/`) - this file should contain typings for the package.
 

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -17,52 +17,52 @@ Example `tsconfig.json` files:
 
 * Using the `"files"` property
 
-    ```json
-    {
-        "compilerOptions": {
-            "module": "commonjs",
-            "noImplicitAny": true,
-            "removeComments": true,
-            "preserveConstEnums": true,
-            "out": "../../built/local/tsc.js",
-            "sourceMap": true
-        },
-        "files": [
-            "core.ts",
-            "sys.ts",
-            "types.ts",
-            "scanner.ts",
-            "parser.ts",
-            "utilities.ts",
-            "binder.ts",
-            "checker.ts",
-            "emitter.ts",
-            "program.ts",
-            "commandLineParser.ts",
-            "tsc.ts",
-            "diagnosticInformationMap.generated.ts"
-        ]
-    }
-    ```
+  ```json
+  {
+      "compilerOptions": {
+          "module": "commonjs",
+          "noImplicitAny": true,
+          "removeComments": true,
+          "preserveConstEnums": true,
+          "out": "../../built/local/tsc.js",
+          "sourceMap": true
+      },
+      "files": [
+          "core.ts",
+          "sys.ts",
+          "types.ts",
+          "scanner.ts",
+          "parser.ts",
+          "utilities.ts",
+          "binder.ts",
+          "checker.ts",
+          "emitter.ts",
+          "program.ts",
+          "commandLineParser.ts",
+          "tsc.ts",
+          "diagnosticInformationMap.generated.ts"
+      ]
+  }
+  ```
 
 * Using the `"exclude"` property
 
-    ```json
-    {
-        "compilerOptions": {
-            "module": "commonjs",
-            "noImplicitAny": true,
-            "removeComments": true,
-            "preserveConstEnums": true,
-            "out": "../../built/local/tsc.js",
-            "sourceMap": true
-        },
-        "exclude": [
-            "node_modules",
-            "wwwroot"
-        ]
-    }
-    ```
+  ```json
+  {
+      "compilerOptions": {
+          "module": "commonjs",
+          "noImplicitAny": true,
+          "removeComments": true,
+          "preserveConstEnums": true,
+          "out": "../../built/local/tsc.js",
+          "sourceMap": true
+      },
+      "exclude": [
+          "node_modules",
+          "wwwroot"
+      ]
+  }
+  ```
 
 ## Details
 


### PR DESCRIPTION
Addresses issue of relating code block to a previous list item. See https://github.com/gettalong/kramdown/issues/123 for details.