### PR TITLE
Add example typing for "Function Module" pattern

### DIFF
--- a/pages/Writing Definition Files.md
+++ b/pages/Writing Definition Files.md
@@ -230,6 +230,25 @@ declare var Eagle: Eagle;
 export = Eagle;
 ```
 
+## Module as a Function
+
+#### Usage
+
+```ts
+// Common pattern for node modules (e.g. rimraf, debug, request, etc.)
+import sayHello = require('say-hello');
+sayHello('Travis');
+```
+
+#### Typing
+
+```ts
+declare module 'say-hello' {
+  function sayHello(name: string): void;
+  export = sayHello;
+}
+```
+
 ## Callbacks
 
 #### Usage


### PR DESCRIPTION
Many node modules such as rimraf, debug, mkdirp, etc. export a single
function by default that can then be used by clients. This commit adds
an example of writing a typing for this pattern. Node module authors
will be able to look at this example and immediately understand how to
write a type defintion for their package.

Fixes #141.