### PR TITLE
Classes: Use more obvious syntax for typeof.

### DIFF
--- a/pages/Classes.md
+++ b/pages/Classes.md
@@ -422,7 +422,7 @@ let greeter1: Greeter;
 greeter1 = new Greeter();
 console.log(greeter1.greet());
 
-let greeterMaker: typeof Greeter = Greeter;
+let greeterMaker: (typeof Greeter) = Greeter;
 greeterMaker.standardGreeting = "Hey there!";
 
 let greeter2: Greeter = new greeterMaker();


### PR DESCRIPTION
It is not obvious at first glance what is exactly going on. I think putting parenthesis there makes it more clear.

Not sure if it needs to be mention that the parenthesis are optional.