### PR TITLE
React-webpack guide: list react/react-dom as externals 

### DIFF
--- a/pages/quick-start/react-webpack.md
+++ b/pages/quick-start/react-webpack.md
@@ -167,7 +167,7 @@ module.exports = {
             { test: /\.js$/, loader: "source-map-loader" }
         ]
     },
-    
+
     externals: {
         "react": "React",
         "react-dom": "ReactDOM",

--- a/pages/quick-start/react-webpack.md
+++ b/pages/quick-start/react-webpack.md
@@ -117,6 +117,8 @@ Create a file at the root of `proj` named `index.html` with the following conten
     </head>
     <body>
         <div id="example"></div>
+        <script src="./node_modules/react/dist/react.js"></script>
+        <script src="./node_modules/react-dom/dist/react-dom.js"></script>
         <script src="./dist/bundle.js"></script>
     </body>
 </html>
@@ -164,6 +166,11 @@ module.exports = {
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
             { test: /\.js$/, loader: "source-map-loader" }
         ]
+    },
+    
+    externals: {
+        "react": "React",
+        "react-dom": "ReactDOM",
     }
 };
 ```


### PR DESCRIPTION
webpack.config.js in [react-webpack guide](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/quick-start/react-webpack.md#create-a-webpack-configuration-file) should list react and react-dom as externals otherwise the library code gets packed into your bundle.js, which usually is not what you want. 