### PR TITLE
fix Decorators page, parameter part code can't run

### DIFF
--- a/pages/Decorators.md
+++ b/pages/Decorators.md
@@ -360,14 +360,16 @@ import "reflect-metadata";
 const requiredMetadataKey = Symbol("required");
 
 function required(target: Object, propertyKey: string|symbol, parameterIndex: number) {
-    Reflect.defineMetadata(requiredMetadataKey, true, target, parameterIndex);
+    let map = new Map();
+    Reflect.defineMetadata(requiredMetadataKey, map.set(parameterIndex, true), target, propertyKey);
 }
 
 function validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) {
     let method = descriptor.value;
     descriptor.value = function () {
+        let metadata = Reflect.getOwnMetadata(requiredMetadataKey, target, propertyName);
         for (let parameterIndex = 0; parameterIndex < method.length; parameterIndex++) {
-            if (Reflect.getOwnMetadata(requiredMetadataKey, method, parameterIndex)) {
+            if (metadata && metadata.get(parameterIndex) {
                 if (parameterIndex >= arguments.length || arguments[parameterIndex] === undefined) {
                     throw new Error("Missing required argument.");
                 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes # Decorators page, Parameter Decorators
run invoke `Reflect.defineMetadata(requiredMetadataKey, true, target, parameterIndex);` and `Reflect.getOwnMetadata(requiredMetadataKey, method, parameterIndex)`
