### PR TITLE
Fix wording in Classes.md on name private member

### DIFF
--- a/pages/Classes.md
+++ b/pages/Classes.md
@@ -157,7 +157,7 @@ We also have a new class `Employee` that looks identical to `Animal` in terms of
 We create some instances of these classes and then try to assign them to each other to see what will happen.
 Because `Animal` and `Rhino` share the `private` side of their shape from the same declaration of `private name: string` in `Animal`, they are compatible. However, this is not the case for `Employee`.
 When we try to assign from an `Employee` to `Animal` we get an error that these types are not compatible.
-Even though `Employee` also has a `private` member called `name`, it's not the as the one we declared in `Animal`.
+Even though `Employee` also has a `private` member called `name`, it's not the one we declared in `Animal`.
 
 ## Understanding `protected`
 


### PR DESCRIPTION
This change fixes a grammatical error introduced in this commit: https://github.com/Microsoft/TypeScript-Handbook/commit/76cb268c82ef6c4474c80c74930ba744060259c0

The fix was made working from the assumption that the referenced commit intended to further shorten the wording in the changed sentence (like changing "it is" to "it's") but did not fully complete that task.

Feel free to reject this pull request, however, and restore the original longer wording for the modified sentence ("it is not the same one as the one we declared") if that is preferred.