### PR TITLE
Fix formatting error / typo in "Generics" section.

### DIFF
--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -221,7 +221,7 @@ alert(stringNumeric.add(stringNumeric.zeroValue, "test"));
 
 Just as with interface, putting the type parameter on the class itself lets us make sure all of the properties of the class are working with the same type.
 
-As we covered in the "Classes" section, a class has two sides to its type: the static side and the instance side.
+As we covered in the [Classes section](./Classes.md), a class has two sides to its type: the static side and the instance side.
 Generic classes are only generic over their instance side rather than their static side, so when working with classes, static members can not use the class's type parameter.
 
 # Generic Constraints

--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -221,7 +221,7 @@ alert(stringNumeric.add(stringNumeric.zeroValue, "test"));
 
 Just as with interface, putting the type parameter on the class itself lets us make sure all of the properties of the class are working with the same type.
 
-As we covered in [Classes|Classes in TypeScript], a class has two side to its type: the static side and the instance side.
+As we covered in "Classes" section, a class has two side to its type: the static side and the instance side.
 Generic classes are only generic over their instance side rather than their static side, so when working with classes, static members can not use the class's type parameter.
 
 # Generic Constraints

--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -221,7 +221,7 @@ alert(stringNumeric.add(stringNumeric.zeroValue, "test"));
 
 Just as with interface, putting the type parameter on the class itself lets us make sure all of the properties of the class are working with the same type.
 
-As we covered in the "Classes" section, a class has two side to its type: the static side and the instance side.
+As we covered in the "Classes" section, a class has two sides to its type: the static side and the instance side.
 Generic classes are only generic over their instance side rather than their static side, so when working with classes, static members can not use the class's type parameter.
 
 # Generic Constraints

--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -221,7 +221,7 @@ alert(stringNumeric.add(stringNumeric.zeroValue, "test"));
 
 Just as with interface, putting the type parameter on the class itself lets us make sure all of the properties of the class are working with the same type.
 
-As we covered in "Classes" section, a class has two side to its type: the static side and the instance side.
+As we covered in the "Classes" section, a class has two side to its type: the static side and the instance side.
 Generic classes are only generic over their instance side rather than their static side, so when working with classes, static members can not use the class's type parameter.
 
 # Generic Constraints


### PR DESCRIPTION
Greetings,

There was a formatting error in the "Generics" section, which is fixed in this PR.

For more information, see the diff.

Thanks.