### PR TITLE
Update --project flag tsconfig.json.md to have two dashes as per spec

### DIFF
--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -7,7 +7,7 @@ A project is compiled in one of the following ways:
 ## Using tsconfig.json
 
 * By invoking tsc with no input files, in which case the compiler searches for the `tsconfig.json` file starting in the current directory and continuing up the parent directory chain.
-* By invoking tsc with no input files and a `-project` (or just `-p`) command line option that specifies the path of a directory containing a `tsconfig.json` file.
+* By invoking tsc with no input files and a `--project` (or just `-p`) command line option that specifies the path of a directory containing a `tsconfig.json` file.
 
 When input files are specified on the command line, `tsconfig.json` files are ignored.
 


### PR DESCRIPTION
Updates docs to say `--project` instead of `-project` (which is actually valid, but inconsistent with cli help and documentation elsewhere)