### PR TITLE
Fix compile errors in Advanced Types.md examples.

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -224,7 +224,7 @@ function getRandomPadder() {
 }
 
 // Type is SpaceRepeatingPadder | StringPadder
-let padder: Padding = getRandomPadder();
+let padder: Padder = getRandomPadder();
 
 if (padder instanceof SpaceRepeatingPadder) {
     padder; // type narrowed to 'SpaceRepeatingPadder'

--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -251,13 +251,13 @@ Here's a simple mixin example:
 
 ```ts
 function extend<T, U>(first: T, second: U): T & U {
-    let result = <T & U> {};
+    let result = <T & U>{};
     for (let id in first) {
-        result[id] = first[id];
+        (<any>result)[id] = (<any>first)[id];
     }
     for (let id in second) {
         if (!result.hasOwnProperty(id)) {
-            result[id] = second[id];
+            (<any>result)[id] = (<any>second)[id];
         }
     }
     return result;
@@ -268,6 +268,11 @@ class Person {
 }
 interface Loggable {
     log(): void;
+}
+class ConsoleLogger implements Loggable {
+    log() {
+        // ...
+    }
 }
 var jim = extend(new Person("Jim"), new ConsoleLogger());
 var n = jim.name;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #

- Change padder type to Padder so there are no type errors.
- Use a type assertion for result, first and second to avoid compile errors.
- Add missing ConsoleLogger class implementing Logger for the mixin example.