### PR TITLE
Add babelify preset and extensions options

### DIFF
--- a/pages/tutorials/Gulp.md
+++ b/pages/tutorials/Gulp.md
@@ -394,11 +394,12 @@ cat dist/bundle.js
 
 ## Babel
 
-First install Babelify.
+First install Babelify and the Babel preset for ES2015.
 Like Uglify, Babelify mangles code, so we'll need vinyl-buffer and gulp-sourcemaps.
+By default Babelify will only process files with extensions of `.js`, `.es`, `.es6` and `.jsx` so we need to add the `.ts` extension as an option to Babelify.
 
 ```shell
-npm install --save-dev babelify vinyl-buffer gulp-sourcemaps
+npm install --save-dev babelify babel-preset-es2015 vinyl-buffer gulp-sourcemaps
 ```
 
 Now change your gulpfile to the following:
@@ -428,7 +429,10 @@ gulp.task('default', ['copyHtml'], function () {
         packageCache: {}
     })
     .plugin(tsify)
-    .transform("babelify")
+    .transform('babelify', {
+        presets: ['es2015'],
+        extensions: ['.ts']
+    })
     .bundle()
     .pipe(source('bundle.js'))
     .pipe(buffer())


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #

I followed the Gulp guide and noticed that Babelify wasn't actually running. After adding `presets: ["es2015"]` and `extensions: ['.ts']` as options to Babelify the TypeScript source is now transpiled.
