### PR TITLE
Fix spelling and grammar mistake for modules-related documentation

### DIFF
--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -205,4 +205,4 @@ That was `tsconfig.json` automatic inclusion.
 That does not embed module resolution as discussed above.
 If the compiler identified a file as a target of a module import, it will be included in the compilation regardless if it was excluded in the previous steps.
 
-So to exclude a file from the compilation, you need to exclude it and all **all** files that has an `import` or `/// <reference path="..." />` directives to it.
+So to exclude a file from the compilation, you need to exclude it and **all** files that have an `import` or `/// <reference path="..." />` directive to it.

--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -557,7 +557,7 @@ export function someFunc() { /* ... */ }
 
 Conversly when importing:
 
-### Explicitlly list imported names
+### Explicitly list imported names
 
 #### Consumer.ts
 

--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -155,7 +155,7 @@ Most people expect the output to be
 ```
 
 Remember what we mentioned earlier about variable capturing?
-Every function expression we pass to `setTimeout` actually refers to the same `i` from the same scope. 
+Every function expression we pass to `setTimeout` actually refers to the same `i` from the same scope.
 
 Let's take a minute to consider that means.
 `setTimeout` will run a function after some number of milliseconds, *but only* after the `for` loop has stopped executing;


### PR DESCRIPTION
Hello.

I came across these minor errors whilst studying through TypeScript modules.

Thanks for the effort on providing the handbook!