### PR TITLE
Fix incorrect information about moduleResolution

### DIFF
--- a/pages/Compiler Options.md
+++ b/pages/Compiler Options.md
@@ -22,7 +22,7 @@ Option                                  | Shorthand | Description
 `--listFiles`                           |           |  Print names of files part of the compilation.
 `--locale`                              |           |  The locale to use to show error messages, e.g. en-us.
 `--mapRoot`                             |           |  Specifies the location where debugger should locate map files instead of generated locations. Use this flag if the .map files will be located at run-time in a different location than than the .js files. The location specified will be embedded in the sourceMap to direct the debugger where the map files where be located.
-`--moduleResolution`                    |           |  Determine how modules get resolved. Either 'node' for Node.js/io.js style resolution, or 'classic' (default).
+`--moduleResolution`                    |           |  Determine how modules get resolved. Either 'node' for Node.js/io.js style resolution, or 'classic' (default is 'node').
 `--newLine`                             |           |  Use the specified end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix)."
 `--noEmit`                              |           |  Do not emit outputs.
 `--noEmitOnError`                       |           |  Do not emit outputs if any errors were reported.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #314 

Based on information in the [module resolution docs](https://www.typescriptlang.org/docs/handbook/module-resolution.html), the default module resolution is now Node and not Classic.

