### PR TITLE
Documentation for include and exclude globs in tsconfig.json

### DIFF
--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -63,7 +63,7 @@ Example `tsconfig.json` files:
       "exclude": [
           "node_modules",
           "**/*.spec.ts"
-      ],
+      ]
   }
   ```
 

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -13,72 +13,51 @@ When input files are specified on the command line, `tsconfig.json` files are ig
 
 ## Examples
 
-Example `tsconfig.json` files:
+Example `tsconfig.json` file:
 
-* Using the `"files"` property
-
-  ```json
-  {
-      "compilerOptions": {
-          "module": "commonjs",
-          "noImplicitAny": true,
-          "removeComments": true,
-          "preserveConstEnums": true,
-          "outFile": "../../built/local/tsc.js",
-          "sourceMap": true
-      },
-      "files": [
-          "core.ts",
-          "sys.ts",
-          "types.ts",
-          "scanner.ts",
-          "parser.ts",
-          "utilities.ts",
-          "binder.ts",
-          "checker.ts",
-          "emitter.ts",
-          "program.ts",
-          "commandLineParser.ts",
-          "tsc.ts",
-          "diagnosticInformationMap.generated.ts"
-      ]
-  }
-  ```
-
-* Using the `"exclude"` property
-
-  ```json
-  {
-      "compilerOptions": {
-          "module": "commonjs",
-          "noImplicitAny": true,
-          "removeComments": true,
-          "preserveConstEnums": true,
-          "outFile": "../../built/local/tsc.js",
-          "sourceMap": true
-      },
-      "exclude": [
-          "node_modules",
-          "wwwroot"
-      ]
-  }
-  ```
+```json
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "outFile": "../../built/local/tsc.js",
+        "sourceMap": true
+    },
+    "files": [
+        "main.ts"
+    ],
+    "include": [
+    "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/*.spec.ts"
+    ],
+}
+```
 
 ## Details
 
 The `"compilerOptions"` property can be omitted, in which case the compiler's defaults are used. See our full list of supported [Compiler Options](./Compiler Options.md).
 
-If no `"files"` property is present in a `tsconfig.json`, the compiler defaults to including all TypeScript (`*.ts` or `*.tsx`) files in the containing directory and subdirectories.
-When a `"files"` property is present, only the specified files are included.
+The `"files"` property takes a list of relative or absolute file paths. The `"include"` and `"exclude"` properties take a list of glob-like file patterns. The supported glob wildcards are:
 
-If the `"exclude"` property is specified, the compiler includes all TypeScript (`*.ts` or `*.tsx`) files in the containing directory and subdirectories except for those files or folders that are excluded.
+* `*` matches zero or more characters (excluding directory separators)
+* `?` matches any one character (excluding directory separators)
+* `**/` recursively matches any subdirectory
 
-The `"files"` property cannot be used in conjunction with the `"exclude"` property. If both are specified then the `"files"` property takes precedence.
+If a segment of a glob pattern includes only `*` or `.*`, then only files with supported extensions are included (e.g. `.ts`, `.tsx`, and `.d.ts` by default with `.js` and `.jsx` if `allowJs` is set to true).
 
-Any files that are referenced by those specified in the `"files"` property are also included.
+If the `"files"` and `"include"` are both left unspecified, the compiler defaults to including all TypeScript (`.ts`, `.d.ts` and `.tsx`) files in the containing directory and subdirectories except those excluded using the `"exclude"` property. JS files (`.js` and `.jsx`) are also included if `allowJs` is set to true. If the `"files"` or `"include"` properties are specified, the compiler will instead include the union of the files included by those two properties. Files in the directory specified using the `"outDir"` compiler option are always excluded unless explicitly included via the `"files"` property (even when the "`exclude`" property is specified).
+
+Files included using `"include"` can be filtered using the `"exclude"` property. However, files included explicitly using the `"files"` property are always included regardless of `"exclude"`. The `"exclude"` property defaults to excluding the `node_modules`, `bower_components`, and `jspm_packages` directories when not specified.
+
+Any files that are referenced by files included via the `"files"` or `"include"` properties are also included.
 Similarly, if a file `B.ts` is referenced by another file `A.ts`, then `B.ts` cannot be excluded unless the referencing file `A.ts` is also specified in the `"exclude"` list.
 
-A `tsconfig.json` file is permitted to be completely empty, which compiles all files in the containing directory and subdirectories with the default compiler options.
+A `tsconfig.json` file is permitted to be completely empty, which compiles all files included by default (as described above) with the default compiler options.
 
 Compiler options specified on the command line override those specified in the `tsconfig.json` file.
 

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -13,30 +13,59 @@ When input files are specified on the command line, `tsconfig.json` files are ig
 
 ## Examples
 
-Example `tsconfig.json` file:
+Example `tsconfig.json` files:
 
-```json
-{
-    "compilerOptions": {
-        "module": "commonjs",
-        "noImplicitAny": true,
-        "removeComments": true,
-        "preserveConstEnums": true,
-        "outFile": "../../built/local/tsc.js",
-        "sourceMap": true
-    },
-    "files": [
-        "main.ts"
-    ],
-    "include": [
-    "src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "**/*.spec.ts"
-    ],
-}
-```
+* Using the `"files"` property
+
+  ```json
+  {
+      "compilerOptions": {
+          "module": "commonjs",
+          "noImplicitAny": true,
+          "removeComments": true,
+          "preserveConstEnums": true,
+          "outFile": "../../built/local/tsc.js",
+          "sourceMap": true
+      },
+      "files": [
+          "core.ts",
+          "sys.ts",
+          "types.ts",
+          "scanner.ts",
+          "parser.ts",
+          "utilities.ts",
+          "binder.ts",
+          "checker.ts",
+          "emitter.ts",
+          "program.ts",
+          "commandLineParser.ts",
+          "tsc.ts",
+          "diagnosticInformationMap.generated.ts"
+      ]
+  }
+  ```
+
+* Using the `"include"` and `"exclude"` properties
+
+  ```json
+  {
+      "compilerOptions": {
+          "module": "commonjs",
+          "noImplicitAny": true,
+          "removeComments": true,
+          "preserveConstEnums": true,
+          "outFile": "../../built/local/tsc.js",
+          "sourceMap": true
+      },
+      "include": [
+          "src/**/*"
+      ],
+      "exclude": [
+          "node_modules",
+          "**/*.spec.ts"
+      ],
+  }
+  ```
 
 ## Details
 

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -42,7 +42,9 @@ Example `tsconfig.json` file:
 
 The `"compilerOptions"` property can be omitted, in which case the compiler's defaults are used. See our full list of supported [Compiler Options](./Compiler Options.md).
 
-The `"files"` property takes a list of relative or absolute file paths. The `"include"` and `"exclude"` properties take a list of glob-like file patterns. The supported glob wildcards are:
+The `"files"` property takes a list of relative or absolute file paths.
+The `"include"` and `"exclude"` properties take a list of glob-like file patterns.
+The supported glob wildcards are:
 
 * `*` matches zero or more characters (excluding directory separators)
 * `?` matches any one character (excluding directory separators)
@@ -50,9 +52,13 @@ The `"files"` property takes a list of relative or absolute file paths. The `"in
 
 If a segment of a glob pattern includes only `*` or `.*`, then only files with supported extensions are included (e.g. `.ts`, `.tsx`, and `.d.ts` by default with `.js` and `.jsx` if `allowJs` is set to true).
 
-If the `"files"` and `"include"` are both left unspecified, the compiler defaults to including all TypeScript (`.ts`, `.d.ts` and `.tsx`) files in the containing directory and subdirectories except those excluded using the `"exclude"` property. JS files (`.js` and `.jsx`) are also included if `allowJs` is set to true. If the `"files"` or `"include"` properties are specified, the compiler will instead include the union of the files included by those two properties. Files in the directory specified using the `"outDir"` compiler option are always excluded unless explicitly included via the `"files"` property (even when the "`exclude`" property is specified).
+If the `"files"` and `"include"` are both left unspecified, the compiler defaults to including all TypeScript (`.ts`, `.d.ts` and `.tsx`) files in the containing directory and subdirectories except those excluded using the `"exclude"` property. JS files (`.js` and `.jsx`) are also included if `allowJs` is set to true.
+If the `"files"` or `"include"` properties are specified, the compiler will instead include the union of the files included by those two properties.
+Files in the directory specified using the `"outDir"` compiler option are always excluded unless explicitly included via the `"files"` property (even when the "`exclude`" property is specified).
 
-Files included using `"include"` can be filtered using the `"exclude"` property. However, files included explicitly using the `"files"` property are always included regardless of `"exclude"`. The `"exclude"` property defaults to excluding the `node_modules`, `bower_components`, and `jspm_packages` directories when not specified.
+Files included using `"include"` can be filtered using the `"exclude"` property.
+However, files included explicitly using the `"files"` property are always included regardless of `"exclude"`.
+The `"exclude"` property defaults to excluding the `node_modules`, `bower_components`, and `jspm_packages` directories when not specified.
 
 Any files that are referenced by files included via the `"files"` or `"include"` properties are also included.
 Similarly, if a file `B.ts` is referenced by another file `A.ts`, then `B.ts` cannot be excluded unless the referencing file `A.ts` is also specified in the `"exclude"` list.


### PR DESCRIPTION
Fixes #324

This PR adds documentation for the glob support in tsconfig.json. I took the explanation of glob wildcards from the [original glob PR](https://github.com/Microsoft/TypeScript/pull/5980) by @rbuckton 