### PR TITLE
Fix broken link to tsconfig.json doc

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -119,7 +119,7 @@ Simply create a new file in your project root named `tsconfig.json` and fill it 
 We're including `typings/index.d.ts`, which Typings created for us.
 That file automatically includes all of your installed dependencies.
 
-You can learn more about `tsconfig.json` files [here](../tsconfig.json.md).
+You can learn more about `tsconfig.json` files [here](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 
 # Write some code
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #

The link is broken on the [website](http://www.typescriptlang.org/docs/handbook/react-&-webpack.html)