### PR TITLE
Fixed typings/index.d.ts filename in tsconfig.json

### DIFF
--- a/pages/tutorials/ASP.NET Core.md
+++ b/pages/tutorials/ASP.NET Core.md
@@ -258,7 +258,7 @@ The tsconfig should now look like this:
       "./app.ts",
       "./model.ts",
       "./main.ts",
-      "../typings/main.d.ts"
+      "../typings/index.d.ts"
   ],
   "compileOnSave": true
 }


### PR DESCRIPTION
Corrected `typings/main.d.ts` to `typings/index.d.ts` for #371. `index` is what is stated in the above paragraph and is the correct filename (`main.d.ts` doesn't exist in the `typings` folder).

