### PR TITLE
Fix grammatical errors

### DIFF
--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -57,13 +57,14 @@ let output = identity<string>("myString");  // type of output will be 'string'
 
 Here we explicitly set `T` to be string as one of the arguments to the function call, denoted using the `<>` around the arguments rather than `()`.
 
-The second way is also perhaps the most common. Here we use *type argument inference*, that is, we want the compiler to set the value of `T` for us automatically based on the type of the argument we pass in:
+The second way is also perhaps the most common. Here we use *type argument inference* -- that is, we want the compiler to set the value of `T` for us automatically based on the type of the argument we pass in:
 
 ```ts
 let output = identity("myString");  // type of output will be 'string'
 ```
 
-Notice that we didn't have to explicitly pass the type in the angle brackets (`<>`), the compiler just looked at the value `"myString"`, and set `T` to its type.
+Notice that we didn't have to explicitly pass the type in the angle brackets (`<>`). The compiler just looked at the value `"myString"`, and set `T` to its type.
+
 While type argument inference can be a helpful tool to keep code shorter and more readable, you may need to explicitly pass in the type arguments as we did in the previous example when the compiler fails to infer the type, as may happen in more complex examples.
 
 # Working with Generic Type Variables


### PR DESCRIPTION
Before these corrections, both sentences incorrectly used [comma splices](https://en.wikipedia.org/wiki/Comma_splice).