### PR TITLE
fixed bug in configureation example

### DIFF
--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -38,7 +38,7 @@ Let's create a bare-bones one for our project:
 {
     "compilerOptions": {
         "outDir": "./built",
-        "allowJS": true,
+        "allowJs": true,
         "target": "es5"
     },
     "include": [


### PR DESCRIPTION
The example configuration was not working (i.e. error TS5023: Unknown compiler option 'allowJS'.). This fixes the documentation with lower case letter "s".