### PR TITLE
Fix 'allowJs' casing in migration guide.

### DIFF
--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -38,7 +38,7 @@ Let's create a bare-bones one for our project:
 {
     "compilerOptions": {
         "outDir": "./built",
-        "allowJS": true,
+        "allowJs": true,
         "target": "es5"
     },
     "include": [


### PR DESCRIPTION
This causes build failures for users as noted [here](https://twitter.com/jeremy_wiebe/status/779537870876925952). @mhegazy