### PR TITLE
Fixing a code typo so as to match the intent.

### DIFF
--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -525,7 +525,8 @@ class TextBox extends Control {
     select() { }
 }
 
-class Image extends Control {
+class Image {
+    select() { }
 }
 
 class Location {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #

The image class should not extend Control class as is the intent mention in the last paragraph of the document. Here is what documentation says
"Effectively, a `SelectableControl` acts like a `Control` that is known to have a `select` method.
The `Button` and `TextBox` classes are subtypes of `SelectableControl` (because they both inherit from `Control` and have a `select` method), but the `Image` and `Location` classes are not."