### PR TITLE
Mention module concatenation possibilities with TS1.8

### DIFF
--- a/pages/Namespaces and Modules.md
+++ b/pages/Namespaces and Modules.md
@@ -114,4 +114,5 @@ Here's a revised example:
 ## Trade-offs of Modules
 
 Just as there is a one-to-one correspondence between JS files and modules, TypeScript has a one-to-one correspondence between module source files and their emitted JS files.
-One effect of this is that it's not possible to use the `--outFile` compiler switch to concatenate multiple module source files into a single JavaScript file.
+One effect of this is that it's not possible to concatenate multiple module source files depending on the module system you target.
+For instance, you can't use the `outFile` option while targeting `commonjs` or `umd`, but with TypeScript 1.8 and later, [it's possible](https://www.typescriptlang.org/docs/release-notes/typescript-1.8.html#concatenate-amd-and-system-modules-with---outfile) to use `outFile` when targeting `amd` or `system`.


### PR DESCRIPTION
In the section Namespaces and Modules you mention in the last sentence that it is not possible to concatenate modules to a single JS-File. However with [TypeScript 1.8](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#concatenate-amd-and-system-modules-with---outfile) it is possible to use the compiler switch `--outFile` together with `--module amd` or `--module system`.