### PR TITLE
Fixed broken link in React Webpack tutorial

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -107,7 +107,7 @@ Simply create a new file in your project root named `tsconfig.json` and fill it 
 }
 ```
 
-You can learn more about `tsconfig.json` files [here](../tsconfig.json.md).
+You can learn more about `tsconfig.json` files [here](../../tsconfig.json.md).
 
 # Write some code
 


### PR DESCRIPTION
Updated the path reference to the page about tsconfig.json as it was broken.