### PR TITLE
Does not require `this.` before props in the stateless example

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -117,7 +117,7 @@ import * as React from "react";
 
 export interface HelloProps { compiler: string; framework: string; }
 
-const Hello = (props: HelloProps) => <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
+const Hello = (props: HelloProps) => <h1>Hello from {props.compiler} and {props.framework}!</h1>;
 
 ```
 


### PR DESCRIPTION
If it remains `this.props.xxx`, it will throw `Uncaught TypeError: Cannot read property 'compiler' of undefined` on `Hello.tsx:5`