### PR TITLE
`Hello` must be exported to be used in `index.tsx`

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -117,7 +117,7 @@ import * as React from "react";
 
 export interface HelloProps { compiler: string; framework: string; }
 
-const Hello = (props: HelloProps) => <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
+export const Hello = (props: HelloProps) => <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
 
 ```
 


### PR DESCRIPTION
`Hello` must be exported to be used in `index.tsx`, or else an error is thrown:

```
ERROR in [at-loader] src/index.tsx:4:10
    Module '"/home/administrator/projects/walker-portal/src/src/components/Hello"' has no exported member 'Hello'.
```