### PR TITLE
Mention there are currently 2 webpack loaders for typescript and link…

### DIFF
--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -123,17 +123,12 @@ module.exports = {
 };
 ```
 
-It's important to note several things:
+It's important to note that awesome-typescript-loader will need to run before any other loader that deals with `.js` files.
 
-`awesome-typescript-loader` will need to run before any other loader that deals with `.js` files.
+The same goes for [ts-loader](https://github.com/TypeStrong/ts-loader), another TypeScript loader for Webpack.
+You can read more about the differences between the two [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader).
 
 You can see an example of using Webpack in our [tutorial on React and Webpack](./React & Webpack.md).
-
-awesome-typescript-loader is not the only loader for typescript.
-
-You could instead use [ts-loader](https://github.com/TypeStrong/ts-loader).
-
-Read about the differences between them [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader)
 
 # Moving to TypeScript Files
 

--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -83,11 +83,11 @@ You can read more there.
 ## Webpack
 
 Webpack integration is pretty simple.
-You can use `ts-loader`, a TypeScript loader, combined with `source-map-loader` for easier debugging.
+You can use `awesome-typescript-loader`, a TypeScript loader, combined with `source-map-loader` for easier debugging.
 Simply run
 
 ```shell
-npm install ts-loader source-map-loader
+npm install awesome-typescript-loader source-map-loader
 ```
 
 and merge in options from the following into your `webpack.config.js` file:
@@ -109,8 +109,8 @@ module.exports = {
 
     module: {
         loaders: [
-            // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
-            { test: /\.tsx?$/, loader: "ts-loader" }
+            // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+            { test: /\.tsx?$/, loader: "awesome-typescript-loader" }
         ],
 
         preLoaders: [
@@ -123,8 +123,17 @@ module.exports = {
 };
 ```
 
-It's important to note that `ts-loader` will need to run before any other loader that deals with `.js` files.
+It's important to note several things:
+
+`awesome-typescript-loader` will need to run before any other loader that deals with `.js` files.
+
 You can see an example of using Webpack in our [tutorial on React and Webpack](./React & Webpack.md).
+
+awesome-typescript-loader is not the only loader for typescript.
+
+You could instead use [ts-loader](https://github.com/TypeStrong/ts-loader).
+
+Read about the differences between them [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader)
 
 # Moving to TypeScript Files
 

--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -79,6 +79,10 @@ awesome-typescript-loader helps Webpack compile your TypeScript code using the T
 source-map-loader uses any sourcemap outputs from TypeScript to inform webpack when generating *its own* sourcemaps.
 This will allow you to debug your final output file as if you were debugging your original TypeScript source code.
 
+Please note that awesome-typescript-loader is not the only loader for typescript.
+You could instead use [ts-loader](https://github.com/TypeStrong/ts-loader).
+Read about the differences between them [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader)
+
 Notice that we installed TypeScript as a development dependency.
 We could also have linked TypeScript to a global copy with `npm link typescript`, but this is a less common scenario.
 


### PR DESCRIPTION
Fixes #450

Consistently use awesome-webpack-loader across documentation and mention there is an alternative.
As well as include a link to more information about the differences between the 2 loaders.