### PR TITLE
Fix two small errors in React + Webpack tutorial.

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -101,6 +101,9 @@ Simply create a new file in your project root named `tsconfig.json` and fill it 
     },
     "include": [
         "./**/*"
+    ],
+    "exclude": [
+        "node_modules"
     ]
 }
 ```
@@ -117,7 +120,7 @@ import * as React from "react";
 
 export interface HelloProps { compiler: string; framework: string; }
 
-const Hello = (props: HelloProps) => <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
+export const Hello = (props: HelloProps) => <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
 
 ```
 


### PR DESCRIPTION
This fixes two issues I ran into while reading through the tutorial.

The first issue is that `node_modules` needs to be explicitly excluded, otherwise you end up with a bunch of "Cannot redeclare..." errors. (I'm not sure if this is the best solution here, feel free to let me know if there is a better way to handle this.)

The second issue is that the Hello component wasn't exported, resulting in a compile error.