### PR TITLE
Fix incorrect language of codeblock in namespaces

### DIFF
--- a/pages/Namespaces.md
+++ b/pages/Namespaces.md
@@ -196,7 +196,7 @@ If multiple JS files get produced, we'll need to use `<script>` tags on our webp
 
 ##### MyTestPage.html (excerpt)
 
-```ts
+```html
     <script src="Validation.js" type="text/javascript" />
     <script src="LettersOnlyValidator.js" type="text/javascript" />
     <script src="ZipCodeValidator.js" type="text/javascript" />


### PR DESCRIPTION
Fix incorrect source language in https://www.typescriptlang.org/docs/handbook/namespaces.html

![namespaces typescript 2016-12-31 10-21-08](https://cloud.githubusercontent.com/assets/19714/21575029/de118fe0-cf42-11e6-9dd1-c6eeb605290f.png)

`ts` => `html`.