### PR TITLE
Fix typo in last example in Generics

### DIFF
--- a/pages/Generics.md
+++ b/pages/Generics.md
@@ -319,9 +319,7 @@ class Lion extends Animal {
     keeper: ZooKeeper;
 }
 
-function findKeeper<A extends Animal, K> (a: {new(): A;
-    prototype: {keeper: K}}): K {
-
+function findKeeper<A extends Animal, K> (a: {new(): A, prototype: {keeper: K}}): K {
     return a.prototype.keeper;
 }
 


### PR DESCRIPTION
I don't know all the syntaxes of TypeScript, but this seems like a typo.