### PR TITLE
add warning about behavior of "include" option

### DIFF
--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -91,6 +91,9 @@ The `"exclude"` property defaults to excluding the `node_modules`, `bower_compon
 Any files that are referenced by files included via the `"files"` or `"include"` properties are also included.
 Similarly, if a file `B.ts` is referenced by another file `A.ts`, then `B.ts` cannot be excluded unless the referencing file `A.ts` is also specified in the `"exclude"` list.
 
+Please note that the compiler does not include files that can be possible outputs; e.g. if the input includes `index.ts`, then `index.d.ts` and `index.js` is excluded.
+We do not recommend having files that differ only in extension next to each other, that breaks assumptions the compiler makes about module resolution.
+
 A `tsconfig.json` file is permitted to be completely empty, which compiles all files included by default (as described above) with the default compiler options.
 
 Compiler options specified on the command line override those specified in the `tsconfig.json` file.

--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -91,8 +91,8 @@ The `"exclude"` property defaults to excluding the `node_modules`, `bower_compon
 Any files that are referenced by files included via the `"files"` or `"include"` properties are also included.
 Similarly, if a file `B.ts` is referenced by another file `A.ts`, then `B.ts` cannot be excluded unless the referencing file `A.ts` is also specified in the `"exclude"` list.
 
-Please note that the compiler does not include files that can be possible outputs; e.g. if the input includes `index.ts`, then `index.d.ts` and `index.js` is excluded.
-We do not recommend having files that differ only in extension next to each other, that breaks assumptions the compiler makes about module resolution.
+Please note that the compiler does not include files that can be possible outputs; e.g. if the input includes `index.ts`, then `index.d.ts` and `index.js` are excluded.
+In general, having files that differ only in extension next to each other is not recomended.
 
 A `tsconfig.json` file is permitted to be completely empty, which compiles all files included by default (as described above) with the default compiler options.
 


### PR DESCRIPTION
The pull request is inspired by [issue #13739 in TypeScript](https://github.com/Microsoft/TypeScript/issues/13739).

I want to prevent creating similar issues in future and for that I'd like to add this clarification from @mhegazy. Since it was not a 100% obvious aspect of the compiler's behavior, this experience might be useful for the others. 