### PR TITLE
Add missing assignment in Index Types example

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -693,7 +693,10 @@ interface Person {
     name: string;
     age: number;
 }
-let person: Person;
+let person: Person = {
+    name: 'Jarid',
+    age: 35
+};
 let strings: string[] = pluck(person, ['name']); // ok, string[]
 ```
 


### PR DESCRIPTION
`module.ts(10,31): error TS2454: Variable 'person' is used before being assigned.`