### PR TITLE
Fix npm option for saving package in package.json for Migrating from JavaScript.md

### DIFF
--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -214,7 +214,7 @@ Luckily this is pretty easy.
 If TypeScript complains about a package like `lodash`, you can just write
 
 ```shell
-npm install -s @types/lodash
+npm install -S @types/lodash
 ```
 
 If you're using a module option other than `commonjs`, you'll need to set your `moduleResolution` option to `node`.


### PR DESCRIPTION
The short form of options for the npm command are case sensitive. Therefore "npm -s" is wrong and has to be "npm -S" instead.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->