### PR TITLE
Update React & Webpack.md

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -203,19 +203,23 @@ module.exports = {
 
     resolve: {
         // Add '.ts' and '.tsx' as resolvable extensions.
-        extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
+        extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
     },
 
     module: {
-        loaders: [
-            // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { test: /\.tsx?$/, loader: "awesome-typescript-loader" }
+        rules: [
+            {
+                enforce: 'pre',
+                test: /\.js$/,
+                loader: 'source-map-loader',
+                exclude: /(node_modules)/,
+            },
+            {
+                test: /\.tsx?$/,
+                loaders: ['awesome-typescript-loader'],
+                exclude: /(node_modules)/
+            },
         ],
-
-        preLoaders: [
-            // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { test: /\.js$/, loader: "source-map-loader" }
-        ]
     },
 
     // When importing a module whose path matches one of the following, just


### PR DESCRIPTION
Since Webpack 2.2 (now the last stable version), some breaking changes were introduced in config that affects this example :
- The "empty" extension is now more needed (and forbidden)
- No more "preLoader" options, must use the module rules format

Fixes #495 #462
