### PR TITLE
Fix object type statement

### DIFF
--- a/pages/declaration files/Do's and Don'ts.md
+++ b/pages/declaration files/Do's and Don'ts.md
@@ -17,9 +17,8 @@ function reverse(s: String): String;
 function reverse(s: string): string;
 ```
 
-If you're tempted to use the type `Object`, consider using `any` instead.
-There is currently no way in TypeScript to specify an object that is "not a primitive".
-<!--(Revisit if/when #1809 is implemented)-->
+Instead of `Object`, you can use the new `object` type added in TypeScript 2.2.
+Follow [this link](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) for more info.
 
 ## Generics
 

--- a/pages/declaration files/Do's and Don'ts.md
+++ b/pages/declaration files/Do's and Don'ts.md
@@ -17,8 +17,7 @@ function reverse(s: String): String;
 function reverse(s: string): string;
 ```
 
-Instead of `Object`, you can use the new `object` type added in TypeScript 2.2.
-Follow [this link](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) for more info.
+Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2.2](../release notes/TypeScript 2.2.md#object-type)).
 
 ## Generics
 


### PR DESCRIPTION
Since TypeScript 2.2, you can use object type for non-primitives, so that sentence wasn't true anymore

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

This fixes an issue opened in TypeScript repo: https://github.com/Microsoft/TypeScript/issues/14340#issuecomment-282836413
