### PR TITLE
Update link to decorators spec

### DIFF
--- a/pages/Decorators.md
+++ b/pages/Decorators.md
@@ -2,7 +2,7 @@
 
 With the introduction of Classes in TypeScript and ES6, there now exist certain scenarios that require additional features to support annotating or modifying classes and class members.
 Decorators provide a way to add both annotations and a meta-programming syntax for class declarations and members.
-Decorators are a [stage 1 proposal](https://github.com/wycats/javascript-decorators/blob/master/README.md) for JavaScript and are available as an experimental feature of TypeScript.
+Decorators are a [stage 2 proposal](https://github.com/tc39/proposal-decorators) for JavaScript and are available as an experimental feature of TypeScript.
 
 > NOTE&emsp; Decorators are an experimental feature that may change in future releases.
 


### PR DESCRIPTION
Fixes #508
At this moment the Decorators Proposal has reached stage 2 and also proposal text have been moved under TC39 organization.

See [updated link](https://github.com/tc39/proposal-decorators) as a reference.