### PR TITLE
'constructor' typo in migration from javascript tutorial

### DIFF
--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -391,7 +391,7 @@ For instance, imagine a `Point` class, and imagine a function that we wish to ad
 
 ```ts
 class Point {
-    constuctor(public x, public y) {}
+    constructor(public x, public y) {}
     getDistance(p: Point) {
         let dx = p.x - this.x;
         let dy = p.y - this.y;


### PR DESCRIPTION
Fixes #553