### PR TITLE
Suggestion to change 'type' to 'destructuring' to describe function declaration with destructuring and default values

### DIFF
--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -578,7 +578,7 @@ function f({ a, b }: C): void {
 ```
 
 But specifying defaults is more common for parameters, and getting defaults right with destructuring can be tricky.
-First of all, you need to remember to put the destructuring before the default value.
+First of all, you need to remember to put the pattern before the default value.
 
 ```ts
 function f({ a, b } = { a: "", b: 0 }): void {

--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -578,7 +578,7 @@ function f({ a, b }: C): void {
 ```
 
 But specifying defaults is more common for parameters, and getting defaults right with destructuring can be tricky.
-First of all, you need to remember to put the type before the default value.
+First of all, you need to remember to put the destructuring before the default value.
 
 ```ts
 function f({ a, b } = { a: "", b: 0 }): void {
@@ -586,6 +586,8 @@ function f({ a, b } = { a: "", b: 0 }): void {
 }
 f(); // ok, default to { a: "", b: 0 }
 ```
+
+> The snippet above is an example of type inference, explained later in the handbook.
 
 Then, you need to remember to give a default for optional properties on the destructured property instead of the main initializer.
 Remember that `C` was defined with `b` optional:


### PR DESCRIPTION
Fixes #558 
