### PR TITLE
Add closing backtick to Person

### DIFF
--- a/pages/release notes/TypeScript 2.1.md
+++ b/pages/release notes/TypeScript 2.1.md
@@ -57,7 +57,7 @@ setProperty(x, "foo", "string"); // Error!, string expected number
 # Mapped Types
 
 One common task is to take an existing type and make each of its properties entirely optional.
-Let's say we have a `Person:
+Let's say we have a `Person`:
 
 ```ts
 interface Person {


### PR DESCRIPTION
Fixes a typo where there was a missing backtick for `Person`.
