### PR TITLE
Fix error in "install dependencies" section of the Gulp handbook

### DIFF
--- a/pages/tutorials/Gulp.md
+++ b/pages/tutorials/Gulp.md
@@ -46,8 +46,7 @@ You can always go back and change these in the `package.json` file that's been g
 ## Install our dependencies
 
 Now we can use `npm install` to install packages.
-First install TypeScript and gulp globally.
-(You might need to start `npm install` commands in this guide with `sudo` if you're on a Unix system.)
+First install `gulp-cli` globally (if you use a Unix system, you may need to prefix the `npm install` commands in this guide with `sudo`).
 
 ```shell
 npm install -g gulp-cli


### PR DESCRIPTION
As described in issue #572:

> The Gulp handbook states that the user should "install TypeScript and gulp globally." However, the associated code example installs the gulp-cli package globally (and nothing else).

Fixes #572
