### PR TITLE
Fixed typo

### DIFF
--- a/pages/release notes/TypeScript 2.3.md
+++ b/pages/release notes/TypeScript 2.3.md
@@ -112,7 +112,7 @@ TypeScript 2.3 adds support for declaring defaults for generic type parameters.
 
 ##### Example
 
-Consider a function that creates a new `HTMLElement`, calling it with no arguments generats an `Div`; you can optionally pass a list of children as well. Previously you would have to define it as:
+Consider a function that creates a new `HTMLElement`, calling it with no arguments generates a `Div`; you can optionally pass a list of children as well. Previously you would have to define it as:
 
 ```ts
 declare function create(): Container<HTMLDivElement, HTMLDivElement[]>;


### PR DESCRIPTION
I noticed this while reading the 2.3 release notes.

(Side note: it would be great to have an edit button on the typescriptlang.org web page, to easily find the right file on GitHub when suggesting edits. Like the Edit button [here](http://aurelia.io/hub.html#/doc/article/aurelia/framework/latest/contact-manager-tutorial/1). I can file a separate issue about that if you like?)
