### PR TITLE
Fix a broken link to atom-typescript

### DIFF
--- a/pages/tsconfig.json.md
+++ b/pages/tsconfig.json.md
@@ -199,7 +199,7 @@ Setting a top-level property `compileOnSave` signals to the IDE to generate all 
 }
 ```
 
-This feature is currently supported in Visual Studio 2015 with TypeScript 1.8.4 and above, and [atom-typescript](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#compileonsave) plugin.
+This feature is currently supported in Visual Studio 2015 with TypeScript 1.8.4 and above, and [atom-typescript](https://github.com/TypeStrong/atom-typescript#compile-on-save) plugin.
 
 ## Schema
 


### PR DESCRIPTION
This PR fixes a broken link to the atom-typescript's README section about the `compileOnSave` feature.