### PR TITLE
Update Integrating with Build Tools.md to use latest WebPack configuration

### DIFF
--- a/pages/Integrating with Build Tools.md
+++ b/pages/Integrating with Build Tools.md
@@ -156,20 +156,26 @@ module.exports = {
     },
     resolve: {
         // Add '.ts' and '.tsx' as a resolvable extension.
-        extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
+        extensions: [".ts", ".tsx", ".js"]
     },
     module: {
-        loaders: [
-            // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
-            { test: /\.tsx?$/, loader: "ts-loader" }
+        rules: [
+            {
+                // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
+                loader: 'ts-loader',
+                test: /\.tsx?$/,
+                exclude: /node_modules/,
+            }
         ]
     }
 }
 ```
 
+See [more details on Webpack and TypeScript here](https://webpack.js.org/guides/webpack-and-typescript).
+
 See [more details on ts-loader here](https://www.npmjs.com/package/ts-loader).
 
-Alternatives:
+Alternatives to ts-loader:
 
 * [awesome-typescript-loader](https://www.npmjs.com/package/awesome-typescript-loader)
 


### PR DESCRIPTION
Update webpack.config.js code, as element module{ loaders:[...]} does not exist anymore in the latest webpack version. It's now module{rules[...]}. See also basic webpack.config.js on https://webpack.js.org/guides/webpack-and-typescript/.
Also added a link to that webpack.js.org-pack that shows the typescript integration

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
