### PR TITLE
Fixed markdown hyperlink not linking

### DIFF
--- a/pages/Compiler Options.md
+++ b/pages/Compiler Options.md
@@ -81,4 +81,6 @@ Option                                         | Type      | Default            
 ## Related
 
 * Setting compiler options in [`tsconfig.json`](./tsconfig.json.md) files.
-* Setting compiler options in [MSBuild projects](./Compiler Options in MSBuild.md).
+* Setting compiler options in [MSBuild projects](./Compiler%20Options%20in%20MSBuild.md).
+
+


### PR DESCRIPTION
Fixed the "MSBuild projects" link at bottom of page to be a hyperlink. Had to encode the spaces in the relative link.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
