### PR TITLE
Add 2.5 compiler options for MSBuild to handbook

### DIFF
--- a/pages/Compiler Options in MSBuild.md
+++ b/pages/Compiler Options in MSBuild.md
@@ -63,6 +63,7 @@ Compiler Option                              | MSBuild Property Name            
 `--noImplicitReturns`                        | TypeScriptNoImplicitReturns                | boolean
 `--noImplicitThis`                           | TypeScriptNoImplicitThis                   | boolean
 `--noImplicitUseStrict`                      | TypeScriptNoImplicitUseStrict              | boolean
+`--noStrictGenericChecks`                    | TypeScriptNoStrictGenericChecks            | boolean
 `--noUnusedLocals`                           | TypeScriptNoUnusedLocals                   | boolean
 `--noUnusedParameters`                       | TypeScriptNoUnusedParameters               | boolean
 `--noLib`                                    | TypeScriptNoLib                            | boolean
@@ -72,6 +73,7 @@ Compiler Option                              | MSBuild Property Name            
 `--outFile`                                  | TypeScriptOutFile                          | File path
 `--paths`                                    | *Not supported in MSBuild*                 |
 `--preserveConstEnums`                       | TypeScriptPreserveConstEnums               | boolean
+`--preserveSymlinks`                         | TypeScriptPreserveSymlinks                 | boolean
 `--listEmittedFiles`                         | *Not supported in MSBuild*                 |
 `--pretty`                                   | *Not supported in MSBuild*                 |
 `--reactNamespace`                           | TypeScriptReactNamespace                   | string


### PR DESCRIPTION
Adds `noStrictGenericChecks` and `preserveSymlinks` per #17848 