### PR TITLE
Fix react component type passed to generic

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -134,8 +134,8 @@ import * as React from "react";
 export interface HelloProps { compiler: string; framework: string; }
 
 // 'HelloProps' describes the shape of props.
-// State is never set so we use the 'undefined' type.
-export class Hello extends React.Component<HelloProps, undefined> {
+// State is never set so we use the '{}' type.
+export class Hello extends React.Component<HelloProps, {}> {
     render() {
         return <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
     }


### PR DESCRIPTION
`undefined` throws this

```
[ts]
JSX element type 'Hello' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: undefined, props: HelloProps) => Pick<undefined, K>, callback?...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pick<{}, K>, callback?: (() => any) | undef...'.
      Types of parameters 'f' and 'f' are incompatible.
        Types of parameters 'prevState' and 'prevState' are incompatible.
          Type 'undefined' is not assignable to type '{}'.
```

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
