### PR TITLE
Remove "algebraic data types"

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -543,7 +543,7 @@ Much of the time when we talk about "singleton types", we're referring to both e
 
 # Discriminated Unions
 
-You can combine singleton types, union types, type guards, and type aliases to build an advanced pattern called *discriminated unions*, also known as *tagged unions* or *algebraic data types*.
+You can combine singleton types, union types, type guards, and type aliases to build an advanced pattern called *discriminated unions*, also known as *tagged unions*.
 Discriminated unions are useful in functional programming.
 Some languages automatically discriminate unions for you; TypeScript instead builds on JavaScript patterns as they exist today.
 There are three ingredients:


### PR DESCRIPTION
This is incorrect. A tagged union is one way to implement sum types, which is a kind of algebraic data type. However, product types (another common ADT) is not possible in TypeScript.


<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->


