### PR TITLE
Don't even mention the entry point for running `npm init` in the React/Webpack sample.

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -45,8 +45,7 @@ Now we'll turn this folder into an npm package.
 npm init
 ```
 
-You'll be given a series of prompts.
-You can use the defaults except for your entry point.
+You'll be given a series of prompts, but you can feel free to use the defaults.
 You can always go back and change these in the `package.json` file that's been generated for you.
 
 # Install our dependencies


### PR DESCRIPTION
Fixes #668.