### PR TITLE
Use an actual number instead of `number`.

### DIFF
--- a/pages/Enums.md
+++ b/pages/Enums.md
@@ -174,7 +174,7 @@ interface Square {
 let c: Circle = {
     kind: ShapeKind.Square,
     //    ~~~~~~~~~~~~~~~~ Error!
-    radius: number,
+    radius: 100,
 }
 ```
 


### PR DESCRIPTION
Fixes #658.