### PR TITLE
Add --strict compiler option in msbuild

### DIFF
--- a/pages/Compiler Options in MSBuild.md
+++ b/pages/Compiler Options in MSBuild.md
@@ -84,6 +84,7 @@ Compiler Option                              | MSBuild Property Name            
 `--skipDefaultLibCheck`                      | TypeScriptSkipDefaultLibCheck              | boolean
 `--sourceMap`                                | TypeScriptSourceMap                        | File path
 `--sourceRoot`                               | TypeScriptSourceRoot                       | File path
+`--strict`                                   | TypeScriptStrict                           | boolean
 `--strictFunctionTypes`                      | TypeScriptStrictFunctionTypes              | boolean
 `--strictNullChecks`                         | TypeScriptStrictNullChecks                 | boolean
 `--stripInternal`                            | TypeScriptStripInternal                    | boolean


### PR DESCRIPTION
The `--strict` flag was added in https://github.com/Microsoft/TypeScript/pull/14486