### PR TITLE
Fix syntax error: use `function` instead of `const` in declaration

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -554,7 +554,7 @@ For example:
 ##### math-lib.d.ts
 
 ```ts
-export const isPrime(x: number): boolean;
+export function isPrime(x: number): boolean;
 export as namespace mathLib;
 ```
 


### PR DESCRIPTION
This PR fixes a small syntax error / typo where a function was declared with the wrong keyword.

Fixes Microsoft/TypeScript#14047