### PR TITLE
Remove inaccurate section about type alias names

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -447,22 +447,7 @@ type Yikes = Array<Yikes>; // error
 
 ## Interfaces vs. Type Aliases
 
-As we mentioned, type aliases can act sort of like interfaces; however, there are some subtle differences.
-
-One difference is that interfaces create a new name that is used everywhere.
-Type aliases don't create a new name &mdash; for instance, error messages won't use the alias name.
-In the code below, hovering over `interfaced` in an editor will show that it returns an `Interface`, but will show that `aliased` returns object literal type.
-
-```ts
-type Alias = { num: number }
-interface Interface {
-    num: number;
-}
-declare function aliased(arg: Alias): Alias;
-declare function interfaced(arg: Interface): Interface;
-```
-
-A second more important difference is that type aliases cannot be extended or implemented from (nor can they extend/implement other types).
+The most important difference is that type aliases cannot be extended or implemented from (nor can they extend/implement other types).
 Because [an ideal property of software is being open to extension](https://en.wikipedia.org/wiki/Open/closed_principle), you should always use an interface over a type alias if possible.
 
 On the other hand, if you can't express some shape with an interface and you need to use a union or tuple type, type aliases are usually the way to go.


### PR DESCRIPTION
Likely true at one point, but right now aliases actually do create a name that is used for Intellisense and errors. However, if you make aliases of another alias it just uses the first alias name; this has been marked as a bug, but it's possibly intended behavior: https://github.com/Microsoft/TypeScript/issues/19198

[Playground Demo](http://www.typescriptlang.org/play/#src=type%20Alias%20%3D%20%7B%20num%3A%20number%20%7D%0D%0Ainterface%20Interface%20%7B%0D%0A%20%20%20%20num%3A%20number%3B%0D%0A%7D%0D%0Adeclare%20function%20aliased(arg%3A%20Alias)%3A%20Alias%3B%0D%0Adeclare%20function%20interfaced(arg%3A%20Interface)%3A%20Interface%3B%0D%0A%0D%0Aconst%20alias%3A%20Alias%20%3D%20%7B%20num%3A%201%20%7D%3B%20%0D%0Aconst%20foo%3A%20string%20%3D%20aliased(alias)%3B)