### PR TITLE
Method decorator factory is missing return type

### DIFF
--- a/pages/Decorators.md
+++ b/pages/Decorators.md
@@ -48,7 +48,7 @@ A *Decorator Factory* is simply a function that returns the expression that will
 We can write a decorator factory in the following fashion:
 
 ```ts
-function color(value: string) { // this is the decorator factory
+function color(value: string): any { // this is the decorator factory
     return function (target) { // this is the decorator
         // do something with 'target' and 'value'...
     }
@@ -203,6 +203,10 @@ If the method decorator returns a value, it will be used as the *Property Descri
 
 > NOTE&emsp; The return value is ignored if your script target is less than `ES5`.
 
+A return type is expected at the method decorator factory and it must be `any` or `void`.
+
+> NOTE&emsp; If no return is supplied, the method decorator will not be acceptable.
+
 The following is an example of a method decorator (`@enumerable`) applied to a method on the `Greeter` class:
 
 ```ts
@@ -222,7 +226,7 @@ class Greeter {
 We can define the `@enumerable` decorator using the following function declaration:
 
 ```ts
-function enumerable(value: boolean) {
+function enumerable(value: boolean): any {
     return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
         descriptor.enumerable = value;
     };


### PR DESCRIPTION
The example supplied in Method Decorator is not working in TS `2.6` because a return type is expected in the method decorator factory and it must be `any` or `void`.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
