### PR TITLE
change 'non-primitive' to 'primitive'

### DIFF
--- a/pages/declaration files/Do's and Don'ts.md
+++ b/pages/declaration files/Do's and Don'ts.md
@@ -17,7 +17,7 @@ function reverse(s: String): String;
 function reverse(s: string): string;
 ```
 
-Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2.2](../release notes/TypeScript 2.2.md#object-type)).
+Instead of `Object`, use the primitive `object` type ([added in TypeScript 2.2](../release notes/TypeScript 2.2.md#object-type)).
 
 ## Generics
 


### PR DESCRIPTION
The documentation refers to `object` as "non-primitive" instead of "primitive".