### PR TITLE
Added clarification about scripts and global scope

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -17,6 +17,7 @@ At runtime the module loader is responsible for locating and executing all depen
 Well-known modules loaders used in JavaScript are the [CommonJS](https://en.wikipedia.org/wiki/CommonJS) module loader for Node.js and [require.js](http://requirejs.org/) for Web applications.
 
 In TypeScript, just as in ECMAScript 2015, any file containing a top-level `import` or `export` is considered a module.
+Conversely, a file without any top-level `import` or `export` declarations is treated as a script whose contents are available in the global scope (and therefore to modules as well).
 
 # Export
 


### PR DESCRIPTION
See https://github.com/Microsoft/TypeScript/issues/21109

Although the documentation already mentions what is required for a file to be considered a module, it may not be clear to everyone how exactly TypeScript behaves in the opposite case.

I've added a clarification. Feel free to rephrase it.