### PR TITLE
Replace "field" with "property"

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -849,7 +849,7 @@ type Flags = {
 ```
 
 Real applications, however, look like `Readonly` or `Partial` above.
-They're based on some existing type, and they transform the fields in some way.
+They're based on some existing type, and they transform the properties in some way.
 That's where `keyof` and indexed access types come in:
 
 ```ts


### PR DESCRIPTION
1. TypeScript doesn't introduce the concept of "fields" (as in [C# fields](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/fields)). TypeScript only has properties.
2. This is the only place in the handbook  where the word `field` is used. In all other places, we find that the word `property` is used. Best to be consistent.