### PR TITLE
Fix typo in optional interface property example

### DIFF
--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -85,7 +85,7 @@ interface SquareConfig {
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
     let newSquare = {color: "white", area: 100};
-    if (config.color) {
+    if (config.clor) {
         // Error: Property 'clor' does not exist on type 'SquareConfig'
         newSquare.color = config.clor;
     }


### PR DESCRIPTION
As I was reading the example code, I stumpled upon this one line, which does not seem logical to me.
I believe it is supposed to be the way I changed it.
