### PR TITLE
Add code highlighting for webpack loaders names

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -76,11 +76,11 @@ npm install --save-dev typescript awesome-typescript-loader source-map-loader
 ```
 
 Both of these dependencies will let TypeScript and webpack play well together.
-awesome-typescript-loader helps Webpack compile your TypeScript code using the TypeScript's standard configuration file named `tsconfig.json`.
-source-map-loader uses any sourcemap outputs from TypeScript to inform webpack when generating *its own* sourcemaps.
+`awesome-typescript-loader` helps Webpack compile your TypeScript code using the TypeScript's standard configuration file named `tsconfig.json`.
+`source-map-loader` uses any sourcemap outputs from TypeScript to inform webpack when generating *its own* sourcemaps.
 This will allow you to debug your final output file as if you were debugging your original TypeScript source code.
 
-Please note that awesome-typescript-loader is not the only loader for typescript.
+Please note that `awesome-typescript-loader` is not the only loader for typescript.
 You could instead use [ts-loader](https://github.com/TypeStrong/ts-loader).
 Read about the differences between them [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
Add highlighting for webpack loaders `awesome-typescript-loader`, `source-map-loader`
(Just to make reading easier)