### PR TITLE
Add a step to avoid a compiler error in VSCode

### DIFF
--- a/pages/tutorials/TypeScript in 5 minutes.md
+++ b/pages/tutorials/TypeScript in 5 minutes.md
@@ -35,7 +35,13 @@ document.body.innerHTML = greeter(user);
 We used a `.ts` extension, but this code is just JavaScript.
 You could have copy/pasted this straight out of an existing JavaScript app.
 
-At the command line, run the TypeScript compiler:
+At command line, navigate to folder that contains your `greeter.ts` and initialize it as a TypeScript project:
+
+```shell
+tsc --init
+```
+
+Then, run the TypeScript compiler:
 
 ```shell
 tsc greeter.ts


### PR DESCRIPTION
Add a step to "TypeScript in 5 minutes" for avoiding a cryptic compiler/intellisense error in VSCode (see https://stackoverflow.com/q/44192541/426379).