### PR TITLE
Fix for ESLint "Unexpected trailing comma" warning

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -224,7 +224,7 @@ module.exports = {
     externals: {
         "react": "React",
         "react-dom": "ReactDOM"
-    },
+    }
 };
 ```
 


### PR DESCRIPTION
Visual Studio 2017 raises a warning if you use the provided Webpack configuration file.