### PR TITLE
Add `object` to basic types handbook

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -240,6 +240,24 @@ function infiniteLoop(): never {
 }
 ```
 
+# Object
+
+`object` is a type that represents the non-primitive type, i.e. any thing that is not `number`, `string`, `boolean`, `symbol`, `null`, or `undefined`.
+
+With `object` type, APIs like `Object.create` can be better represented. For example:
+
+```ts
+declare function create(o: object | null): void;
+
+create({ prop: 0 }); // OK
+create(null); // OK
+
+create(42); // Error
+create("string"); // Error
+create(false); // Error
+create(undefined); // Error
+```
+
 # Type assertions
 
 Sometimes you'll end up in a situation where you'll know more about a value than TypeScript does.


### PR DESCRIPTION
when I'm learning typescript from the handbook
I don't know if there is a object type, because the handbook doesn't have a documentation for it.
I know `object` type from stackoverflow's question, and after searching I found the documentation that mention `object` type it's in [What's New section ](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/release%20notes/TypeScript%202.2.md)

I think it's better to mention it explicitly in Basic Types Handbook