### PR TITLE
Correct syntax typo for import statement

### DIFF
--- a/pages/declaration files/Library Structures.md
+++ b/pages/declaration files/Library Structures.md
@@ -94,7 +94,7 @@ var fs = require("fs");
 In TypeScript or ES6, the `import` keyword serves the same purpose:
 
 ```ts
-import fs = require("fs");
+import fs from "fs";
 ```
 
 You'll typically see modular libraries include one of these lines in their documentation:


### PR DESCRIPTION
This corrects the syntax for the example import statement.