### PR TITLE
[Proposition] replace pluck by props in Advanced types > Index type

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -706,7 +706,7 @@ With index types, you can get the compiler to check code that uses dynamic prope
 For example, a common Javascript pattern is to pick a subset of properties from an object:
 
 ```js
-function pluck(o, names) {
+function props(o, names) {
     return names.map(n => o[n]);
 }
 ```
@@ -714,7 +714,7 @@ function pluck(o, names) {
 Here's how you would write and use this function in TypeScript, using the **index type query** and **indexed access** operators:
 
 ```ts
-function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {
+function props<T, K extends keyof T>(o: T, names: K[]): T[K][] {
   return names.map(n => o[n]);
 }
 
@@ -726,7 +726,7 @@ let person: Person = {
     name: 'Jarid',
     age: 35
 };
-let strings: string[] = pluck(person, ['name']); // ok, string[]
+let strings: string[] = props(person, ['name']); // ok, string[]
 ```
 
 The compiler checks that `name` is actually a property on `Person`.
@@ -741,11 +741,11 @@ let personProps: keyof Person; // 'name' | 'age'
 
 `keyof Person` is completely interchangeable with `'name' | 'age'`.
 The difference is that if you add another property to `Person`, say `address: string`, then `keyof Person` will automatically update to be `'name' | 'age' | 'address'`.
-And you can use `keyof` in generic contexts like `pluck`, where you can't possibly know the property names ahead of time.
-That means the compiler will check that you pass the right set of property names to `pluck`:
+And you can use `keyof` in generic contexts like `props`, where you can't possibly know the property names ahead of time.
+That means the compiler will check that you pass the right set of property names to `props`:
 
 ```ts
-pluck(person, ['age', 'unknown']); // error, 'unknown' is not in 'name' | 'age'
+props(person, ['age', 'unknown']); // error, 'unknown' is not in 'name' | 'age'
 ```
 
 The second operator is `T[K]`, the **indexed access operator**.


### PR DESCRIPTION
Change #

The guilty:

```
function pluck(o, names) {
     return names.map(n => o[n]);
}
```

The name pluck can be confusing.
In ramda or underscore pluck is passing a property name and map each object of the array to that property name.
In lodash it's just a map.
In RxJS you map to emitted value to a property (each argument being a new depth).
etc....
Here it's again different (the array contains the props of the object you want)

If we can just name this "props" or what suits you it would be less confusing and we could read the document without needing to reading the implementation of the function.

What do you think?
