### PR TITLE
The target of TypeScript is es6

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -101,7 +101,7 @@ Simply create a new file in your project root named `tsconfig.json` and fill it 
         "sourceMap": true,
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react"
     },
     "include": [


### PR DESCRIPTION
The target of TypeScript is es6. If target is es5,have error message "ERROR in [at-loader] ./node_modules/@types/node/index.d.ts"
![image](https://user-images.githubusercontent.com/14011130/40670936-1761d81e-639d-11e8-874e-53b2fc7613d1.png)

