### PR TITLE
Fixed destructing function declaration example

### DIFF
--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -583,7 +583,7 @@ First of all, you need to remember to put the pattern before the default value.
 function f({ a="", b=0 }): void {
     // ...
 }
-f(); // ok, default to { a: "", b: 0 }
+f();
 ```
 
 > The snippet above is an example of type inference, explained later in the handbook.

--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -580,7 +580,7 @@ But specifying defaults is more common for parameters, and getting defaults righ
 First of all, you need to remember to put the pattern before the default value.
 
 ```ts
-function f({ a, b } = { a: "", b: 0 }): void {
+function f({ a="", b=0 }): void {
     // ...
 }
 f(); // ok, default to { a: "", b: 0 }

--- a/pages/Variable Declarations.md
+++ b/pages/Variable Declarations.md
@@ -580,7 +580,7 @@ But specifying defaults is more common for parameters, and getting defaults righ
 First of all, you need to remember to put the pattern before the default value.
 
 ```ts
-function f({ a="", b=0 }): void {
+function f({ a="", b=0 } = {}): void {
     // ...
 }
 f();


### PR DESCRIPTION
Fixes #729. 

The change involves removing the old example which was deemed wrong by @DanielRosenwasser in the issue above, and replaced it with the same user's suggested fix.
