### PR TITLE
Remove unused `cards` member variable from examples.

### DIFF
--- a/pages/Functions.md
+++ b/pages/Functions.md
@@ -234,7 +234,6 @@ Let's look at an example:
 ```ts
 let deck = {
     suits: ["hearts", "spades", "clubs", "diamonds"],
-    cards: Array(52),
     createCardPicker: function() {
         return function() {
             let pickedCard = Math.floor(Math.random() * 52);
@@ -266,7 +265,6 @@ Arrow functions capture the `this` where the function is created rather than whe
 ```ts
 let deck = {
     suits: ["hearts", "spades", "clubs", "diamonds"],
-    cards: Array(52),
     createCardPicker: function() {
         // NOTE: the line below is now an arrow function, allowing us to capture 'this' right here
         return () => {
@@ -309,12 +307,10 @@ interface Card {
 }
 interface Deck {
     suits: string[];
-    cards: number[];
     createCardPicker(this: Deck): () => Card;
 }
 let deck: Deck = {
     suits: ["hearts", "spades", "clubs", "diamonds"],
-    cards: Array(52),
     // NOTE: The function now explicitly specifies that its callee must be of type Deck
     createCardPicker: function(this: Deck) {
         return () => {


### PR DESCRIPTION
Cards member is not used by any of the examples, and I think it adds one extra thing to read that distracts from the point of each example. This removes the declaration.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
