### PR TITLE
Fix an error in "Type Inference.md"

### DIFF
--- a/pages/Type Inference.md
+++ b/pages/Type Inference.md
@@ -50,7 +50,7 @@ This is known as "contextual typing". Contextual typing occurs when the type of 
 
 ```ts
 window.onmousedown = function(mouseEvent) {
-    console.log(mouseEvent.button);  //<- Error
+    console.log(mouseEvent.badPropertyName);  //<- Error
 };
 ```
 
@@ -63,7 +63,7 @@ Had we written the above example:
 
 ```ts
 window.onmousedown = function(mouseEvent: any) {
-    console.log(mouseEvent.button);  //<- Now, no error is given
+    console.log(mouseEvent.badPropertyName);  //<- Now, no error is given
 };
 ```
 


### PR DESCRIPTION
The original code block:
```typescript
window.onmousedown = function(mouseEvent) {
    console.log(mouseEvent.button);  //<- Error
};
```
really don't give an "error" because `button` **is** a property of type `MouseEvent`(the type that is inferred).

To demonstrate the "type inference" of TypeScript, here I changed the code block into:
```typescript
window.onmousedown = function(mouseEvent) {
    console.log(mouseEvent.badPropertyName);  //<- Error
};
```
The same is done to the next code block for comparison:
```typescript
window.onmousedown = function(mouseEvent: any) {
    console.log(mouseEvent.badPropertyName);  //<- No error
};
```