### PR TITLE
Revert "Update Compiler Options.md"

### DIFF
--- a/pages/Compiler Options.md
+++ b/pages/Compiler Options.md
@@ -3,7 +3,7 @@
 Option                                         | Type      | Default                        | Description
 -----------------------------------------------|-----------|--------------------------------|----------------------------------------------------------------------
 `--allowJs`                                    | `boolean` | `false`                        | Allow JavaScript files to be compiled.
-`--allowSyntheticDefaultImports`               | `boolean` | `module === "system"` or `--esModuleInterop` is set and `module` is not `es2015`/`esnext` | Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
+`--allowSyntheticDefaultImports`               | `boolean` | `module === "system"` or `--esModuleInterop` | Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
 `--allowUnreachableCode`                       | `boolean` | `false`                        | Do not report errors on unreachable code.
 `--allowUnusedLabels`                          | `boolean` | `false`                        | Do not report errors on unused labels.
 `--alwaysStrict`                               | `boolean` | `false`                        | Parse in strict mode and emit `"use strict"` for each source file


### PR DESCRIPTION
This reverts commit 8e974c814d44381ed05a3b6203894e0f9e39d552.

This supports https://github.com/Microsoft/TypeScript/pull/26866, and thus should not be merged before the code change itself.

I wasn't sure if I'm targeting the right branch with this PR (I couldn't find branch `release-3.1` which I believe @RyanCavanaugh would like the code change to go into), so please let me know if I should change it.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes https://github.com/Microsoft/TypeScript/issues/26193.

/cc @DanielRosenwasser 