### PR TITLE
Fixed typo in tsconfig docs url

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -110,7 +110,7 @@ Simply create a new file in your project root named `tsconfig.json` and fill it 
 }
 ```
 
-You can learn more about `tsconfig.json` files [here](../tsconfig.json.md).
+You can learn more about `tsconfig.json` files [here](./tsconfig.json.md).
 
 # Write some code
 


### PR DESCRIPTION
Fixes #
React & Webpack.MD uses the wrong URL for tsconfig-json.MD