### PR TITLE
Update Type Inference - mouseEvent.button is valid and not a bad example

### DIFF
--- a/pages/Type Inference.md
+++ b/pages/Type Inference.md
@@ -50,7 +50,7 @@ This is known as "contextual typing". Contextual typing occurs when the type of 
 
 ```ts
 window.onmousedown = function(mouseEvent) {
-    console.log(mouseEvent.button);  //<- Error
+    console.log(mouseEvent.myButton);  //<- Error
 };
 ```
 
@@ -63,7 +63,7 @@ Had we written the above example:
 
 ```ts
 window.onmousedown = function(mouseEvent: any) {
-    console.log(mouseEvent.button);  //<- Now, no error is given
+    console.log(mouseEvent.myButton);  //<- Now, no error is given
 };
 ```
 

--- a/pages/Type Inference.md
+++ b/pages/Type Inference.md
@@ -50,7 +50,7 @@ This is known as "contextual typing". Contextual typing occurs when the type of 
 
 ```ts
 window.onmousedown = function(mouseEvent) {
-    console.log(mouseEvent.myButton);  //<- Error
+    console.log(mouseEvent.clickTime);  //<- Error
 };
 ```
 
@@ -63,7 +63,7 @@ Had we written the above example:
 
 ```ts
 window.onmousedown = function(mouseEvent: any) {
-    console.log(mouseEvent.myButton);  //<- Now, no error is given
+    console.log(mouseEvent.clickTime);  //<- Now, no error is given
 };
 ```
 


### PR DESCRIPTION
Fixes [#26472](https://github.com/Microsoft/TypeScript/issues/26472) (in TypeScript repo)

Updated the `mouseEvent.button` example for Contextual Type inheritance and changed it to `mouseEvent.clickTime` so it would probably not be used in the future