### PR TITLE
docs: correct decorator reflect-metadata example

### DIFF
--- a/pages/Decorators.md
+++ b/pages/Decorators.md
@@ -471,7 +471,7 @@ function validate<T>(target: any, propertyKey: string, descriptor: TypedProperty
         if (!(value instanceof type)) {
             throw new TypeError("Invalid type.");
         }
-        set(value);
+        set.call(target, value);
     }
 }
 ```


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes [#26799](https://github.com/Microsoft/TypeScript/issues/26799)

This PR corrects the code example found in the `Metadata` section of the Decorator documentation, which no longer compiled in TypeScript 3.2. The corrected code compiles without issue.

This is my first time contributing to TypeScript; I've read through the Contributing documents, but my sincere apologies if anything needs correcting! Please do let me know.

Thanks! I love TypeScript, would love to give back more, appreciate all that you do here.