### PR TITLE
Change Object to object as it is a non-primitive type

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -160,9 +160,11 @@ let notSure: any = 4;
 notSure.ifItExists(); // okay, ifItExists might exist at runtime
 notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
 
-let prettySure: Object = 4;
-prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
+let prettySure: object = 4;
+prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'object'.
 ```
+
+You might want to read some [Do's and Dont's](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html) about the difference between using `Object` and `object`
 
 The `any` type is also handy if you know some part of the type, but perhaps not all of it.
 For example, you may have an array but the array has a mix of different types:


### PR DESCRIPTION
Fixes [#19908](https://github.com/Microsoft/TypeScript/issues/19908)

Changed the use of Object to object and added the link to Do's and Don'ts