### PR TITLE
Fix a mistake in "Type Checking JavaScript Files"

### DIFF
--- a/pages/Type Checking JavaScript Files.md
+++ b/pages/Type Checking JavaScript Files.md
@@ -45,10 +45,10 @@ class C {
     method() {
         this.constructorOnly = false // error, constructorOnly is a number
         this.constructorUnknown = "plunkbat" // ok, constructorUnknown is string | undefined
-        this.methodOnly = 'ok'  // ok, but y could also be undefined
+        this.methodOnly = 'ok'  // ok, but methodOnly could also be undefined
     }
     method2() {
-        this.methodOnly = true  // also, ok, y's type is string | boolean | undefined
+        this.methodOnly = true  // also, ok, methodOnly's type is string | boolean | undefined
     }
 }
 ```


### PR DESCRIPTION
Not sure how `y` ended up here.