### PR TITLE
Add a comma after a Conjunctive Adverb

### DIFF
--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -141,7 +141,7 @@ For example, an import statement like `import { b } from "./moduleB"` in  `/root
 
 Recall that Node.js looked for a file named `moduleB.js`, then an applicable `package.json`, and then for an `index.js`.
 
-Similarly a non-relative import will follow the Node.js resolution logic, first looking up a file, then looking up an applicable folder.
+Similarly, a non-relative import will follow the Node.js resolution logic, first looking up a file, then looking up an applicable folder.
 So `import { b } from "moduleB"` in source file `/root/src/moduleA.ts` would result in the following lookups:
 
 1. `/root/src/node_modules/moduleB.ts`


### PR DESCRIPTION
The sentence `Similarly, a non-relative import will` needs a comma as `Similarly` is a conjunctive adverb. 
Learn more:
https://writing.wisc.edu/Handbook/ConjAdv.html
http://www.chompchomp.com/terms/conjunctiveadverb.htm
https://en.wikipedia.org/wiki/Conjunctive_adverb

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->
