### PR TITLE
Fix Various Typos

### DIFF
--- a/pages/Classes.md
+++ b/pages/Classes.md
@@ -341,7 +341,7 @@ To prove to ourselves that our accessor is now checking the passcode, we can mod
 A couple of things to note about accessors:
 
 First, accessors require you to set the compiler to output ECMAScript 5 or higher.
-Downlevelling to ECMAScript 3 is not supported.
+Downleveling to ECMAScript 3 is not supported.
 Second, accessors with a `get` and no `set` are automatically inferred to be `readonly`.
 This is helpful when generating a `.d.ts` file from your code, because users of your property can see that they can't change it.
 

--- a/pages/Project References.md
+++ b/pages/Project References.md
@@ -116,7 +116,7 @@ Project references have a few trade-offs you should be aware of.
 Because dependent projects make use of `.d.ts` files that are built from their dependencies, you'll either have to check in certain build outputs *or* build a project after cloning it before you can navigate the project in an editor without seeing spurious errors.
 We're working on a behind-the-scenes .d.ts generation process that should be able to mitigate this, but for now we recommend informing developers that they should build after cloning.
 
-Additionally, to preserve compatability with existing build workflows, `tsc` will *not* automatically build dependencies unless invoked with the `--build` switch.
+Additionally, to preserve compatibility with existing build workflows, `tsc` will *not* automatically build dependencies unless invoked with the `--build` switch.
 Let's learn more about `--build`.
 
 # Build Mode for TypeScript

--- a/pages/tutorials/ASP.NET Core.md
+++ b/pages/tutorials/ASP.NET Core.md
@@ -301,7 +301,7 @@ We need to add:
 
 1. The paths to the library files.
 2. Add a `lib` task to pipe the files to `wwwroot`.
-3. Add a dependendency on `lib` to the `default` task.
+3. Add a dependency on `lib` to the `default` task.
 
 The updated `gulpfile.js` should look like this:
 

--- a/pages/tutorials/React.md
+++ b/pages/tutorials/React.md
@@ -641,4 +641,4 @@ If you want to eject at some point, you may need to know a little bit more about
 You can check out our [React & Webpack walkthrough here](./React & Webpack.md).
 
 At some point you might need routing.
-There are several solutons, but [react-router](https://github.com/ReactTraining/react-router) is probably the most popular for Redux projects, and is often used in conjunction with [react-router-redux](https://github.com/reactjs/react-router-redux).
+There are several solutions, but [react-router](https://github.com/ReactTraining/react-router) is probably the most popular for Redux projects, and is often used in conjunction with [react-router-redux](https://github.com/reactjs/react-router-redux).


### PR DESCRIPTION
Fixed multiple typos:

- `pages/Classes.md` - Downlevelling => Downleveling
- `pages/Project References.md` - compatability => compatibility
- `pages/tutorials/ASP.NET Core.md` - dependendency => dependency
- `pages/tutorials/React.md` - solutons => solutions