### PR TITLE
Avoid unnecessary any casts in advanced types

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -10,33 +10,37 @@ You will mostly see intersection types used for mixins and other concepts that d
 Here's a simple example that shows how to create a mixin:
 
 ```ts
-function extend<T, U>(first: T, second: U): T & U {
-    let result = <T & U>{};
-    for (let id in first) {
-        (<any>result)[id] = (<any>first)[id];
-    }
-    for (let id in second) {
-        if (!result.hasOwnProperty(id)) {
-            (<any>result)[id] = (<any>second)[id];
+function extend<First, Second>(first: First, second: Second): First & Second {
+    const result: Partial<First & Second> = {};
+    for (const prop in first) {
+        if (first.hasOwnProperty(prop)) {
+            (<First>result)[prop] = first[prop];
         }
     }
-    return result;
+    for (const prop in second) {
+        if (second.hasOwnProperty(prop)) {
+            (<Second>result)[prop] = second[prop];
+        }
+    }
+    return <First & Second>result;
 }
 
 class Person {
     constructor(public name: string) { }
 }
+
 interface Loggable {
-    log(): void;
+    log(name: string): void;
 }
+
 class ConsoleLogger implements Loggable {
-    log() {
-        // ...
+    log(name) {
+        console.log(`Hello, I'm ${name}.`);
     }
 }
-var jim = extend(new Person("Jim"), new ConsoleLogger());
-var n = jim.name;
-jim.log();
+
+const jim = extend(new Person('Jim'), ConsoleLogger.prototype);
+jim.log(jim.name);
 ```
 
 # Union Types


### PR DESCRIPTION
- Tighten the typing to avoid unnecessary casts, especially casts to any.
- Use const where possible over mixture of let and var.
- Check Object.hasOwnProperty() in for..in loops.
- Add console.log() invocation so the example prints.

I don't claim the example is perfect but it seems like an improvement.