### PR TITLE
Fix indentation in Enums.md

### DIFF
--- a/pages/Enums.md
+++ b/pages/Enums.md
@@ -120,11 +120,13 @@ An enum member is considered constant if:
 * The enum member is initialized with a constant enum expression.
   A constant enum expression is a subset of TypeScript expressions that can be fully evaluated at compile time.
   An expression is a constant enum expression if it is:
-  1. a literal enum expression (basically a string literal or a numeric literal)
-  2. a reference to previously defined constant enum member (which can originate from a different enum).
-  3. a parenthesized constant enum expression
-  4. one of the `+`, `-`, `~` unary operators applied to constant enum expression
-  5. `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `>>>`, `&`, `|`, `^` binary operators with constant enum expressions as  operands
+
+    1. a literal enum expression (basically a string literal or a numeric literal)
+    2. a reference to previously defined constant enum member (which can originate from a different enum)
+    3. a parenthesized constant enum expression
+    4. one of the `+`, `-`, `~` unary operators applied to constant enum expression
+    5. `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `>>>`, `&`, `|`, `^` binary operators with constant enum expressions as operands
+
   It is a compile time error for constant enum expressions to be evaluated to `NaN` or `Infinity`.
 
 In all other cases enum member is considered computed.


### PR DESCRIPTION
Issue: The [list of conditions for constant enum expressions](https://www.typescriptlang.org/docs/handbook/enums.html#computed-and-constant-members) is formatted improperly:

<img width="991" alt="screenshot of issue" src="https://user-images.githubusercontent.com/10134823/46575011-24c74680-c97b-11e8-9425-6b44a582a967.png">

This PR should fix that by properly indenting the nested list.
