### PR TITLE
Use friendly names for markdownlint config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,36 @@
+{
+    "default": false,
+    "heading-increment": "atx",
+    "ul-style": {
+        "style": "asterisk"
+    },
+    "list-indent": true,
+    "ul-start-left": true,
+    "ul-indent": {
+        "indent": 4
+    },
+    "no-trailing-spaces": true,
+    "no-hard-tabs": true,
+    "no-reversed-links": true,
+    "no-multiple-blanks": true,
+    "no-missing-space-atx": true,
+    "no-multiple-space-atx": true,
+    "blanks-around-headings": true,
+    "heading-start-left": true,
+    "no-trailing-punctuation": {
+        "punctuation": ".,;:!"
+    },
+    "no-multiple-space-blockquote": true,
+    "no-blanks-blockquote": true,
+    "ol-prefix": {
+        "style": "ordered"
+    },
+    "list-marker-space": true,
+    "blanks-around-fences": true,
+    "blanks-around-lists": true,
+    "no-bare-urls": true,
+    "hr-style": "---",
+    "no-space-in-emphasis": true,
+    "no-space-in-links": true,
+    "fenced-code-language": true
+}

--- a/lint.js
+++ b/lint.js
@@ -6,8 +6,7 @@ var inputFiles = glob.sync("**/*.md", { ignore: "node_modules/**/*" });
 var options = {
   files: inputFiles,
   config: {
-    MD001: false, // Header levels should only increment by one level at a time
-    MD002: false, // First header should be a h1 header
+    "default": false, // Let's disable all rules by default
     MD003: "atx", // Header style
     MD004: { style: "asterisk" }, // Unordered list style
     MD005: true, // Inconsistent indentation for list items at the same level
@@ -17,16 +16,10 @@ var options = {
     MD010: true, // Hard tabs
     MD011: true, // Reversed link syntax
     MD012: true, // Multiple consecutive blank lines
-    MD013: false, // Line length
-    MD014: false, // Dollar signs used before commands without showing output
     MD018: true, // No space after hash on atx style header
     MD019: true, // Multiple spaces after hash on atx style header
-    MD020: false, // No space inside hashes on closed atx style header
-    MD021: false, // Multiple spaces inside hashes on closed atx style header
     MD022: true, // Headers should be surrounded by blank lines
     MD023: true, // Headers must start at the beginning of the line
-    MD024: false, // Multiple headers with the same content
-    MD025: false, // Multiple top level headers in the same document
     MD026: { punctuation: ".,;:!" }, // Trailing punctuation in header
     MD027: true, // Multiple spaces after blockquote symbol
     MD028: true, // Blank line inside blockquote
@@ -34,15 +27,11 @@ var options = {
     MD030: true, // Spaces after list markers
     MD031: true, // Fenced code blocks should be surrounded by blank lines
     MD032: true, // Lists should be surrounded by blank lines
-    MD033: false, // Inline HTML
     MD034: true, // Bare URL used
     MD035: "---", // Horizontal rule style
-    MD036: false, // Emphasis used instead of a header
     MD037: true, // Spaces inside emphasis markers
-    MD038: false, // Spaces inside code span elements
     MD039: true, // Spaces inside link text
-    MD040: true, // Fenced code blocks should have a language specified
-    MD041: false, // First line in file should be a top level header
+    MD040: true, // Fenced code blocks should have a language specifieds
   }
 };
 

--- a/lint.js
+++ b/lint.js
@@ -2,37 +2,12 @@ var markdownlint = require("markdownlint");
 var glob = require("glob");
 var fs = require("fs");
 
+var markdownConfig = require("./.markdownlint.json");
+
 var inputFiles = glob.sync("**/*.md", { ignore: "node_modules/**/*" });
 var options = {
   files: inputFiles,
-  config: {
-    "default": false, // Let's disable all rules by default
-    "heading-increment": "atx", // Header style
-    "ul-style": { style: "asterisk" }, // Unordered list style
-    "list-indent": true, // Inconsistent indentation for list items at the same level
-    "ul-start-left": true, // Consider starting bulleted lists at the beginning of the line
-    "ul-indent": { indent: 4 }, // Unordered list indentation
-    "no-trailing-spaces": true, // Trailing spaces
-    "no-hard-tabs": true, // Hard tabs
-    "no-reversed-links": true, // Reversed link syntax
-    "no-multiple-blanks": true, // Multiple consecutive blank lines
-    "no-missing-space-atx": true, // No space after hash on atx style header
-    "no-multiple-space-atx": true, // Multiple spaces after hash on atx style header
-    "blanks-around-headings": true, // Headers should be surrounded by blank lines
-    "heading-start-left": true, // Headers must start at the beginning of the line
-    "no-trailing-punctuation": { punctuation: ".,;:!" }, // Trailing punctuation in header
-    "no-multiple-space-blockquote": true, // Multiple spaces after blockquote symbol
-    "no-blanks-blockquote": true, // Blank line inside blockquote
-    "ol-prefix": { style: "ordered" }, // Ordered list item prefix
-    "list-marker-space": true, // Spaces after list markers
-    "blanks-around-fences": true, // Fenced code blocks should be surrounded by blank lines
-    "blanks-around-lists": true, // Lists should be surrounded by blank lines
-    "no-bare-urls": true, // Bare URL used
-    "hr-style": "---", // Horizontal rule style
-    "no-space-in-emphasis": true, // Spaces inside emphasis markers
-    "no-space-in-links": true, // Spaces inside link text
-    "fenced-code-language": true, // Fenced code blocks should have a language specifieds
-  }
+  config: markdownConfig,
 };
 
 var result = markdownlint.sync(options);

--- a/lint.js
+++ b/lint.js
@@ -7,31 +7,31 @@ var options = {
   files: inputFiles,
   config: {
     "default": false, // Let's disable all rules by default
-    MD003: "atx", // Header style
-    MD004: { style: "asterisk" }, // Unordered list style
-    MD005: true, // Inconsistent indentation for list items at the same level
-    MD006: true, // Consider starting bulleted lists at the beginning of the line
-    MD007: { indent: 4 }, // Unordered list indentation
-    MD009: true, // Trailing spaces
-    MD010: true, // Hard tabs
-    MD011: true, // Reversed link syntax
-    MD012: true, // Multiple consecutive blank lines
-    MD018: true, // No space after hash on atx style header
-    MD019: true, // Multiple spaces after hash on atx style header
-    MD022: true, // Headers should be surrounded by blank lines
-    MD023: true, // Headers must start at the beginning of the line
-    MD026: { punctuation: ".,;:!" }, // Trailing punctuation in header
-    MD027: true, // Multiple spaces after blockquote symbol
-    MD028: true, // Blank line inside blockquote
-    MD029: { style: "ordered" }, // Ordered list item prefix
-    MD030: true, // Spaces after list markers
-    MD031: true, // Fenced code blocks should be surrounded by blank lines
-    MD032: true, // Lists should be surrounded by blank lines
-    MD034: true, // Bare URL used
-    MD035: "---", // Horizontal rule style
-    MD037: true, // Spaces inside emphasis markers
-    MD039: true, // Spaces inside link text
-    MD040: true, // Fenced code blocks should have a language specifieds
+    "heading-increment": "atx", // Header style
+    "ul-style": { style: "asterisk" }, // Unordered list style
+    "list-indent": true, // Inconsistent indentation for list items at the same level
+    "ul-start-left": true, // Consider starting bulleted lists at the beginning of the line
+    "ul-indent": { indent: 4 }, // Unordered list indentation
+    "no-trailing-spaces": true, // Trailing spaces
+    "no-hard-tabs": true, // Hard tabs
+    "no-reversed-links": true, // Reversed link syntax
+    "no-multiple-blanks": true, // Multiple consecutive blank lines
+    "no-missing-space-atx": true, // No space after hash on atx style header
+    "no-multiple-space-atx": true, // Multiple spaces after hash on atx style header
+    "blanks-around-headings": true, // Headers should be surrounded by blank lines
+    "heading-start-left": true, // Headers must start at the beginning of the line
+    "no-trailing-punctuation": { punctuation: ".,;:!" }, // Trailing punctuation in header
+    "no-multiple-space-blockquote": true, // Multiple spaces after blockquote symbol
+    "no-blanks-blockquote": true, // Blank line inside blockquote
+    "ol-prefix": { style: "ordered" }, // Ordered list item prefix
+    "list-marker-space": true, // Spaces after list markers
+    "blanks-around-fences": true, // Fenced code blocks should be surrounded by blank lines
+    "blanks-around-lists": true, // Lists should be surrounded by blank lines
+    "no-bare-urls": true, // Bare URL used
+    "hr-style": "---", // Horizontal rule style
+    "no-space-in-emphasis": true, // Spaces inside emphasis markers
+    "no-space-in-links": true, // Spaces inside link text
+    "fenced-code-language": true, // Fenced code blocks should have a language specifieds
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript-Handbook/issues/872

If we change to disabling markdownlint rules by default, we can simplify the config, and moving some of the config to `.markdownlint.json` allows things like VSCode to pick up the config.