### PR TITLE
added @types folder to module resolution algorithm

### DIFF
--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -148,25 +148,28 @@ So `import { b } from "moduleB"` in source file `/root/src/moduleA.ts` would res
 2. `/root/src/node_modules/moduleB.tsx`
 3. `/root/src/node_modules/moduleB.d.ts`
 4. `/root/src/node_modules/moduleB/package.json` (if it specifies a `"types"` property)
-5. `/root/src/node_modules/moduleB/index.ts`
-6. `/root/src/node_modules/moduleB/index.tsx`
-7. `/root/src/node_modules/moduleB/index.d.ts`
+5. `/root/src/node_modules/@types/moduleB.d.ts`
+6. `/root/src/node_modules/moduleB/index.ts`
+7. `/root/src/node_modules/moduleB/index.tsx`
+8. `/root/src/node_modules/moduleB/index.d.ts`
    <br /><br />
-8. `/root/node_modules/moduleB.ts`
-9. `/root/node_modules/moduleB.tsx`
-10. `/root/node_modules/moduleB.d.ts`
-11. `/root/node_modules/moduleB/package.json` (if it specifies a `"types"` property)
-12. `/root/node_modules/moduleB/index.ts`
-13. `/root/node_modules/moduleB/index.tsx`
-14. `/root/node_modules/moduleB/index.d.ts`
+9. `/root/node_modules/moduleB.ts`
+10. `/root/node_modules/moduleB.tsx`
+11. `/root/node_modules/moduleB.d.ts`
+12. `/root/node_modules/moduleB/package.json` (if it specifies a `"types"` property)
+13. `/root/node_modules/@types/moduleB.d.ts`
+14. `/root/node_modules/moduleB/index.ts`
+15. `/root/node_modules/moduleB/index.tsx`
+16. `/root/node_modules/moduleB/index.d.ts`
     <br /><br />
-15. `/node_modules/moduleB.ts`
-16. `/node_modules/moduleB.tsx`
-17. `/node_modules/moduleB.d.ts`
-18. `/node_modules/moduleB/package.json` (if it specifies a `"types"` property)
-19. `/node_modules/moduleB/index.ts`
-20. `/node_modules/moduleB/index.tsx`
-21. `/node_modules/moduleB/index.d.ts`
+17. `/node_modules/moduleB.ts`
+18. `/node_modules/moduleB.tsx`
+19. `/node_modules/moduleB.d.ts`
+20. `/node_modules/moduleB/package.json` (if it specifies a `"types"` property)
+21. `/node_modules/@types/moduleB.d.ts`
+22. `/node_modules/moduleB/index.ts`
+23. `/node_modules/moduleB/index.tsx`
+24. `/node_modules/moduleB/index.d.ts`
 
 Don't be intimidated by the number of steps here - TypeScript is still only jumping up directories twice at steps (8) and (15).
 This is really no more complex than what Node.js itself is doing.

--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -171,7 +171,7 @@ So `import { b } from "moduleB"` in source file `/root/src/moduleA.ts` would res
 23. `/node_modules/moduleB/index.tsx`
 24. `/node_modules/moduleB/index.d.ts`
 
-Don't be intimidated by the number of steps here - TypeScript is still only jumping up directories twice at steps (8) and (15).
+Don't be intimidated by the number of steps here - TypeScript is still only jumping up directories twice at steps (9) and (17).
 This is really no more complex than what Node.js itself is doing.
 
 ## Additional module resolution flags


### PR DESCRIPTION
I noticed that the @types folder is now part of the algorithm, I felt this documentation needed to reflect that. Using `--traceResolution` will exhibit this new behavior.
Can someone from the core team please verify that this order is correct?
