### PR TITLE
Update Webpack integration handbook, to fix Webpack error.

### DIFF
--- a/pages/Integrating with Build Tools.md
+++ b/pages/Integrating with Build Tools.md
@@ -159,11 +159,11 @@ module.exports = {
         extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
     },
     module: {
-	rules: [{
-		// all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
-		test: /\.tsx?/,
-		use: [ 'ts-loader' ]
-	}]
+        rules: [{
+                // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
+                test: /\.tsx?/,
+                use: [ 'ts-loader' ]
+        }]
     }
 }
 ```

--- a/pages/Integrating with Build Tools.md
+++ b/pages/Integrating with Build Tools.md
@@ -159,10 +159,11 @@ module.exports = {
         extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
     },
     module: {
-        loaders: [
-            // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
-            { test: /\.tsx?$/, loader: "ts-loader" }
-        ]
+	rules: [{
+		// all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
+		test: /\.tsx?/,
+		use: [ 'ts-loader' ]
+	}]
     }
 }
 ```


### PR DESCRIPTION
The current example fails with a syntax error in the latest version of Webpack (4.21.0). I have amended the example to use the new Webpack 4 "rules" syntax (see https://webpack.js.org/concepts/loaders/) and verified the new syntax works in Webpack 4.21.0 with no errors.

Without this change, trying to use the rule will result in the following error:
<< Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module has an unknown property 'loaders'.>>. See also https://stackoverflow.com/questions/49370849/configuration-module-has-an-unknown-property-loaders
