### PR TITLE
Fix a typo in TS3.1 release notes

### DIFF
--- a/pages/release notes/TypeScript 3.1.md
+++ b/pages/release notes/TypeScript 3.1.md
@@ -37,7 +37,7 @@ Here, we have a function `readImage` which reads an image in a non-blocking asyn
 In addition to `readImage`, we've provided a convenience function on `readImage` itself called `readImage.sync`.
 
 While ECMAScript exports are often a better way of providing this functionality, this new support allows code written in this style to "just work" TypeScript.
-Additionaly, this approach for property declarations allows us to express common patterns like `defaultProps` and `propTypes` on React stateless function components (SFCs).
+Additionally, this approach for property declarations allows us to express common patterns like `defaultProps` and `propTypes` on React stateless function components (SFCs).
 
 ```ts
 export const FooComponent => ({ name }) => (


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Found a small typo in the release notes for the latest version.