### PR TITLE
Link address update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 [![Build Status](https://travis-ci.org/Microsoft/TypeScript-Handbook.svg)](https://travis-ci.org/Microsoft/TypeScript-Handbook)
 
 The TypeScript Handbook is a comprehensive guide to the TypeScript language.
-It is meant to be read online at [the TypeScript website](https://www.typescriptlang.org/docs/handbook/basic-types.html) or [directly from this repository](./pages/Basic%20Types.md).
+It is meant to be read online at [the TypeScript website](https://www.typescriptlang.org/docs/home.html) or [directly from this repository](./pages/Basic%20Types.md).
 
 For a more formal description of the language, see the [latest TypeScript Language Specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md).


### PR DESCRIPTION
intro Link goes to home.html instead of basic-types.html

Hi Guys,
New to TypeScript, but the flow is a little better if I am brought to the site of home.html which has a nice introduction and overview page, instead of going straight into basic.types.html - which launches straight into syntax without any introduction.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
