### PR TITLE
Fix typos in Publishing.md

### DIFF
--- a/pages/declaration files/Publishing.md
+++ b/pages/declaration files/Publishing.md
@@ -6,7 +6,7 @@ There are two main ways you can publish your declaration files to npm:
 
 If your package is written in TypeScript then the first approach is favored.
 Use the `--declaration` flag to generate declaration files.
-This way, your declarations and JavaScript always be in sync.
+This way, your declarations and JavaScript will always be in sync.
 
 If your package is not written in TypeScript then the second is the preferred approach.
 
@@ -89,6 +89,6 @@ If your type definitions depend on another package:
 
 # Publish to [@types](https://www.npmjs.com/~types)
 
-Packages on under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/Microsoft/types-publisher).
+Packages under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/Microsoft/types-publisher).
 To get your declarations published as an @types package, please submit a pull request to [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
 You can find more details in the [contribution guidelines page](http://definitelytyped.org/guides/contributing.html).


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #527 

The issue seems to have been already fixed by [this commit](https://github.com/Microsoft/TypeScript-Handbook/commit/884e4e80f0868a2057234796f6a2076e27582d8d#diff-838496c430211cc74d37c3d32399275f) and should be closed.

However I still found some typos to fix.