### PR TITLE
IntelliJ Windows for nightly builds

### DIFF
--- a/pages/Nightly Builds.md
+++ b/pages/Nightly Builds.md
@@ -75,3 +75,8 @@ The nightly build currently does not include the full plugin setup, but we are w
 
 Go to `Preferences` > `Languages & Frameworks` > `TypeScript`:
  > TypeScript Version: If you installed with npm: `/usr/local/lib/node_modules/typescript/lib`
+
+### IntelliJ IDEA (Windows)
+
+Go to `File` > `Settings` > `Languages & Frameworks` > `TypeScript`:
+ > TypeScript Version: If you installed with npm: `C:\Users\USERNAME\AppData\Roaming\npm\node_modules\typescript\lib`


### PR DESCRIPTION
in the same vein as https://github.com/Microsoft/TypeScript-Handbook/pull/413 this pull request ads a note for nightly builds on IntelliJ based IDEs for windows. 

Tested with latest nightly. 

I wasn't sure about how to specify the username in the file location, I've used USERNAME as a placeholder. Please set me know if their is another preferred style.

