### PR TITLE
Use const for symbol when indexing.

### DIFF
--- a/pages/Symbols.md
+++ b/pages/Symbols.md
@@ -22,7 +22,7 @@ sym2 === sym3; // false, symbols are unique
 Just like strings, symbols can be used as keys for object properties.
 
 ```ts
-let sym = Symbol();
+const sym = Symbol();
 
 let obj = {
     [sym]: "value"


### PR DESCRIPTION
* "Type 'symbol' cannot be used as an index type." error is
produced if sym is not const (tsc version 3.1.4).

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->
