### PR TITLE
Remove statement about how files with a single named export are a red flag

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -827,5 +827,4 @@ From the consumption side, the consumer of any given module gets to pick the nam
 All of the following are red flags for module structuring. Double-check that you're not trying to namespace your external modules if any of these apply to your files:
 
 * A file whose only top-level declaration is `export namespace Foo { ... }` (remove `Foo` and move everything 'up' a level)
-* A file that has a single `export class` or `export function` (consider using `export default`)
 * Multiple files that have the same `export namespace Foo {` at top-level (don't think that these are going to combine into one `Foo`!)


### PR DESCRIPTION
Fixes # -- I'm bypassing opening an issue because this is a one line remove and there's this discussion on twitter: https://twitter.com/drosenwasser/status/1061802707160190976

The handbook states:

```
All of the following are red flags for module structuring. Double-check that you're not trying to namespace your external modules if any of these apply to your files:

* ...
* A file that has a single `export class` or `export function` (consider using `export default`)
```

The reason this was done was because the TypeScript team understood it to be good practice (https://twitter.com/drosenwasser/status/1061780825753014272). That was probably because of this statement:

> ES6 favors the single/default export style, and gives the sweetest syntax to importing the default. Importing named exports can and even should be slightly less concise. - https://esdiscuss.org/topic/moduleimport

That said, although a default export may allow for more concise import syntax, a single named export may be useful for helping to keep identifier names in sync across multiple files. Since it offers this advantage it should not be considered a red flag.