### PR TITLE
Avoid confusing with the built-in Map class

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -777,11 +777,11 @@ If you have a type with a string index signature, `keyof T` will just be `string
 And `T[string]` is just the type of the index signature:
 
 ```ts
-interface Map<T> {
+interface Dictionary<T> {
     [key: string]: T;
 }
-let keys: keyof Map<number>; // string
-let value: Map<number>['foo']; // number
+let keys: keyof Dictionary<number>; // string
+let value: Dictionary<number>['foo']; // number
 ```
 
 # Mapped types


### PR DESCRIPTION
During one of the discussion at FullStackTypeScript Slack channel, it turned out this line was a source of confusion — the name `Map` corresponds to the ES2015 built-in class and using this name to describe an object with an index signature was misleading.

I hope this will make it clearer.