### PR TITLE
Fix word wrap for `tsc -b`example

### DIFF
--- a/pages/Project References.md
+++ b/pages/Project References.md
@@ -139,9 +139,9 @@ Just like `tsc -p`, specifying the config file name itself is unnecessary if it'
 You can specify any number of config files:
 
 ```shell
- > tsc -b                                # Build the tsconfig.json in the current directory
- > tsc -b src                            # Build src/tsconfig.json
- > tsc -b foo/release.tsconfig.json bar  # Build foo/release.tsconfig.json and bar/tsconfig.json
+ > tsc -b                            # Use the tsconfig.json in the current directory
+ > tsc -b src                        # Use src/tsconfig.json
+ > tsc -b foo/prd.tsconfig.json bar  # Use foo/prd.tsconfig.json and bar/tsconfig.json
 ```
 
 Don't worry about ordering the files you pass on the commandline - `tsc` will re-order them if needed so that dependencies are always built first.


### PR DESCRIPTION
This fixes the word wrap in the `tsc -b` example which was using very long names and comments.

Compare these screenshots (before and after)

### Before

![before](https://user-images.githubusercontent.com/229881/49023765-ecb3d700-f165-11e8-9529-5dc46ea92bbb.png)


### After 

![after](https://user-images.githubusercontent.com/229881/49023792-ff2e1080-f165-11e8-8a9c-ed25359269f8.png)
