### PR TITLE
Fix transposed JS @typedef declaration

### DIFF
--- a/pages/Type Checking JavaScript Files.md
+++ b/pages/Type Checking JavaScript Files.md
@@ -474,7 +474,7 @@ import types can also be used in type alias declarations:
 
 ```js
 /**
- * @typedef Pet { import("./a").Pet }
+ * @typedef { import("./a").Pet } Pet
  */
 
 /**


### PR DESCRIPTION
The correct syntax for a JSDoc-style `@typedef` is `@typedef {namepath} TypeName`, but the latter two parts were transposed in one section of "Type Checking JavaScript Files."

Before:
```js
/**
 * @typedef Pet { import("./a").Pet }
 */
```

After:
```js
/**
 * @typedef { import("./a").Pet } Pet
 */
```

The rest of the document used the correct syntax.