### PR TITLE
React function component, not stateless functional

### DIFF
--- a/pages/JSX.md
+++ b/pages/JSX.md
@@ -104,12 +104,12 @@ import MyComponent from "./myComponent";
 
 There are two ways to define a value-based element:
 
-1. Stateless Functional Component (SFC)
+1. Function Component
 2. Class Component
 
-Because these two types of value-based elements are indistinguishable from each other in a JSX expression, first TS tries to resolve the expression as Stateless Functional Component using overload resolution. If the process succeeds, then TS finishes resolving the expression to its declaration. If the value fails to resolve as SFC, TS will then try to resolve it as a class component. If that fails, TS will report an error.
+Because these two types of value-based elements are indistinguishable from each other in a JSX expression, first TS tries to resolve the expression as a Function Component using overload resolution. If the process succeeds, then TS finishes resolving the expression to its declaration. If the value fails to resolve as a Function Component, TS will then try to resolve it as a class component. If that fails, TS will report an error.
 
-### Stateless Functional Component
+### Function Component
 
 As the name suggests, the component is defined as JavaScript function where its first argument is a `props` object.
 TS enforces that its return type must be assignable to `JSX.Element`.
@@ -129,7 +129,7 @@ function ComponentFoo(prop: FooProp) {
 const Button = (prop: {value: string}, context: { color: string }) => <button>
 ```
 
-Because an SFC is simply a JavaScript function, function overloads may be used here as well:
+Because a Function Component is simply a JavaScript function, function overloads may be used here as well:
 
 ```ts
 interface ClickableProps {
@@ -239,7 +239,7 @@ It is determined by the type of a property on the *element instance type* that w
 Which property to use is determined by `JSX.ElementAttributesProperty`.
 It should be declared with a single property.
 The name of that property is then used.
-As of TypeScript 2.8, if `JSX.ElementAttributesProperty` is not provided, the type of first parameter of the class element's constructor or SFC's call will be used instead.
+As of TypeScript 2.8, if `JSX.ElementAttributesProperty` is not provided, the type of first parameter of the class element's constructor or Function Component's call will be used instead.
 
 ```ts
 declare namespace JSX {
@@ -279,7 +279,7 @@ declare namespace JSX {
 
 > Note: If an attribute name is not a valid JS identifier (like a `data-*` attribute), it is not considered to be an error if it is not found in the element attributes type.
 
-Additionally, the `JSX.IntrinsicAttributes` interface can be used to specify extra properties used by the JSX framework which are not generally used by the components' props or arguments - for instance `key` in React. Specializing further, the generic `JSX.IntrinsicClassAttributes<T>` type may also be used to specify the same kind of extra attributes just for class components (and not SFCs). In this type, the generic parameter corresponds to the class instance type. In React, this is used to allow the `ref` attribute of type `Ref<T>`. Generally speaking, all of the properties on these interfaces should be optional, unless you intend that users of your JSX framework need to provide some attribute on every tag.
+Additionally, the `JSX.IntrinsicAttributes` interface can be used to specify extra properties used by the JSX framework which are not generally used by the components' props or arguments - for instance `key` in React. Specializing further, the generic `JSX.IntrinsicClassAttributes<T>` type may also be used to specify the same kind of extra attributes just for class components (and not Function Components). In this type, the generic parameter corresponds to the class instance type. In React, this is used to allow the `ref` attribute of type `Ref<T>`. Generally speaking, all of the properties on these interfaces should be optional, unless you intend that users of your JSX framework need to provide some attribute on every tag.
 
 The spread operator also works:
 

--- a/pages/Type Checking JavaScript Files.md
+++ b/pages/Type Checking JavaScript Files.md
@@ -745,10 +745,10 @@ Foo.prototype.sayHi = (greeting) => console.log("Hi!");
 let myArrow = x => x * x;
 
 /**
- * Which means it works for stateless function components in JSX too
+ * Which means it works for function components in JSX too
  * @param {{a: string, b: number}} test - Some param
  */
-var sfc = (test) => <div>{test.a.charAt(0)}</div>;
+var fc = (test) => <div>{test.a.charAt(0)}</div>;
 
 /**
  * A parameter can be a class constructor, using Closure syntax.

--- a/pages/release notes/TypeScript 1.8.md
+++ b/pages/release notes/TypeScript 1.8.md
@@ -129,9 +129,9 @@ switch (x % 3) {
 }
 ```
 
-# Stateless Function Components in React
+# Function Components in React
 
-TypeScript now supports [Stateless Function components](https://reactjs.org/docs/components-and-props.html#functional-and-class-components).
+TypeScript now supports [Function components](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
 These are lightweight components that easily compose other components:
 
 ```ts
@@ -152,7 +152,7 @@ Specifically:
 
 * You no longer need to either explicitly declare `ref` and `key` or `extend React.Props`
 * The `ref` and `key` properties will appear with correct types on all components
-* The `ref` property is correctly disallowed on instances of Stateless Function components
+* The `ref` property is correctly disallowed on instances of Function components
 
 # Augmenting global/module scope from modules
 

--- a/pages/release notes/TypeScript 3.0.md
+++ b/pages/release notes/TypeScript 3.0.md
@@ -315,7 +315,7 @@ The default-ed properties are inferred from the `defaultProps` property type. If
 
 Use `static defaultProps: Pick<Props, "name">;` as an explicit type annotation instead, or do not add a type annotation as done in the example above.
 
-For stateless function components (SFCs) use ES2015 default initializers for SFCs:
+For function components, use ES2015 default initializers:
 
 ```tsx
 function Greet({ name = "world" }: Props) {

--- a/pages/release notes/TypeScript 3.1.md
+++ b/pages/release notes/TypeScript 3.1.md
@@ -37,7 +37,7 @@ Here, we have a function `readImage` which reads an image in a non-blocking asyn
 In addition to `readImage`, we've provided a convenience function on `readImage` itself called `readImage.sync`.
 
 While ECMAScript exports are often a better way of providing this functionality, this new support allows code written in this style to "just work" TypeScript.
-Additionaly, this approach for property declarations allows us to express common patterns like `defaultProps` and `propTypes` on React stateless function components (SFCs).
+Additionaly, this approach for property declarations allows us to express common patterns like `defaultProps` and `propTypes` on React function components.
 
 ```ts
 export const FooComponent => ({ name }) => (

--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -125,7 +125,7 @@ export interface HelloProps { compiler: string; framework: string; }
 export const Hello = (props: HelloProps) => <h1>Hello from {props.compiler} and {props.framework}!</h1>;
 ```
 
-Note that while this example uses [stateless functional components](https://reactjs.org/docs/components-and-props.html#functional-and-class-components), we could also make our example a little *classier* as well.
+Note that while this example uses [function components](https://reactjs.org/docs/components-and-props.html#function-and-class-components), we could also make our example a little *classier* as well.
 
 ```ts
 import * as React from "react";

--- a/pages/tutorials/React.md
+++ b/pages/tutorials/React.md
@@ -142,7 +142,7 @@ function getExclamationMarks(numChars: number) {
 Notice that we defined a type named `Props` that specifies the properties our component will take.
 `name` is a required `string`, and `enthusiasmLevel` is an optional `number` (which you can tell from the `?` that we wrote out after its name).
 
-We also wrote `Hello` as a stateless function component (an SFC).
+We also wrote `Hello` as a function component.
 To be specific, `Hello` is a function that takes a `Props` object, and destructures it.
 If `enthusiasmLevel` isn't given in our `Props` object, it will default to `1`.
 
@@ -170,7 +170,7 @@ class Hello extends React.Component<Props, object> {
 ```
 
 Classes are useful [when our component instances have some state](https://reactjs.org/docs/state-and-lifecycle.html).
-But we don't really need to think about state in this example - in fact, we specified it as `object` in `React.Component<Props, object>`, so writing an SFC tends to be shorter.
+But we don't really need to think about state in this example - in fact, we specified it as `object` in `React.Component<Props, object>`, so writing a function component tends to be shorter.
 Local component state is more useful at the presentational level when creating generic UI elements that can be shared between libraries.
 For our application's lifecycle, we will revisit how applications manage general state with Redux in a bit.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

React no longer refers to function components as "stateless functional components". Functional was changed to function to differentiate from functional programming and "stateless" was dropped with the advent of React Hooks. From the [reactjs.org documentation](https://reactjs.org/docs/hooks-state.html#hooks-and-function-components):

> You might have previously known these as “stateless components”. We’re now introducing the ability to use React state from these, so we prefer the name “function components”.

This PR replaces all instances of "stateless functional component" and "sfc" with "function component".
