### PR TITLE
Update file extension from `.js` to `.ts` in "Module Augmentation".

### DIFF
--- a/pages/Declaration Merging.md
+++ b/pages/Declaration Merging.md
@@ -248,13 +248,13 @@ For information on mimicking class merging, see the [Mixins in TypeScript](./Mix
 Although JavaScript modules do not support merging, you can patch existing objects by importing and then updating them.
 Let's look at a toy Observable example:
 
-```js
-// observable.js
+```ts
+// observable.ts
 export class Observable<T> {
     // ... implementation left as an exercise for the reader ...
 }
 
-// map.js
+// map.ts
 import { Observable } from "./observable";
 Observable.prototype.map = function (f) {
     // ... another exercise for the reader


### PR DESCRIPTION
Perfectly fine if this PR is not accepted but, like @vitoc reported in #562, I'd noticed this subtlety and thought it was worth submitting a PR for.

In that issue, @mhegazy thought this was intentional, however I'm not entirely convinced that it makes sense to keep it the way it is.

Specifically, it seems to me that the use of `.js` is _maybe_ intentional on the (first) `map.js` extension, but questionable on `observable.js` since that example specifies a type variable (i.e. `Observable<T>`): a TypeScript-ism which would render it invalid JavaScript.

The code block directly below this makes mention that:

```ts
// observable.ts stays the same
// map.ts
```

...which would seem to indicate that the `observable.ts` file above was certainly intended to end with `.ts` and remain unchanged.

I'm lead to believe that _both_ `map` an `observable` might be better suited as `.ts` extensions within all mentions of it since the next/following ask is for the reader to add a bunch of TypeScript to the `map` file which was previously `.js` and would need to be renamed to `.ts` to continue with the exercise.

Ultimately, I'm not sure if having the first examples use `.js` extensions is adding much value, but I do think that switching file extensions between blocks might be a subtle nuance that could confuse the reader.

Ref: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
Fixes: https://github.com/Microsoft/TypeScript-Handbook/issues/562