### PR TITLE
Fix error message of union types f function call documentation

### DIFF
--- a/pages/release notes/TypeScript 3.3.md
+++ b/pages/release notes/TypeScript 3.3.md
@@ -31,7 +31,7 @@ declare let f: FruitEater | ColorConsumer;
 
 f("orange"); // It works! Returns a 'number | string'.
 
-f("apple");  // error - Argument of type '"red"' is not assignable to parameter of type '"orange"'.
+f("apple");  // error - Argument of type '"apple"' is not assignable to parameter of type '"orange"'.
 
 f("red");    // error - Argument of type '"red"' is not assignable to parameter of type '"orange"'.
 ```


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes documentation issue
In the `f("apple")` function call, "apple" is used as an argument and not "red" as stated in the error message in the comment.