### PR TITLE
Fix tuple definition

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -92,17 +92,13 @@ console.log(x[0].substr(1)); // OK
 console.log(x[1].substr(1)); // Error, 'number' type does not have 'substr' method
 ```
 
-When accessing an element outside the set of known indices, a union type is used instead:
+Around Typescript 2.5, Tuple became fixed length. Accessing an element outside the set of known indices is not allowed anymore :
 
 ```ts
-x[3] = "world"; // OK, 'string' can be assigned to 'string | number'
-
-console.log(x[5].toString()); // OK, 'string' and 'number' both have 'toString'
-
-x[6] = true; // Error, 'boolean' isn't 'string | number'
+x[2] = "world"; // Error 
+// The third element is not declared in the tuple declaration above
+// So it is not accessible
 ```
-
-Union types are an advanced topic that we'll cover in a later chapter.
 
 # [Enum](Enum)
 

--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -80,14 +80,16 @@ let x: [string, number];
 // Initialize it
 x = ["hello", 10]; // OK
 // Initialize it incorrectly
-x = [10, "hello"]; // Error
+x = [10, "hello"]; // Error 
+// The first elemnt should be a string
+// And the second one should be a number as we declared above
 ```
 
 When accessing an element with a known index, the correct type is retrieved:
 
 ```ts
 console.log(x[0].substr(1)); // OK
-console.log(x[1].substr(1)); // Error, 'number' does not have 'substr'
+console.log(x[1].substr(1)); // Error, 'number' type does not have 'substr' method
 ```
 
 When accessing an element outside the set of known indices, a union type is used instead:

--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -92,7 +92,7 @@ console.log(x[0].substr(1)); // OK
 console.log(x[1].substr(1)); // Error, 'number' type does not have 'substr' method
 ```
 
-Around Typescript 2.5, Tuple became fixed length. Accessing an element outside the set of known indices is not allowed anymore :
+In Typescript 2.7, Tuple became fixed length. Accessing an element outside the set of known indices is not allowed anymore :
 
 ```ts
 x[2] = "world"; // Error 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->
## Motivation
Per this comment https://github.com/Microsoft/TypeScript/issues/28894#issuecomment-445370682 , Tuple type should be fixed width in [Typescript 2.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html). Which means the current document for Tuple type is outdated, My update is to fix this.

## What I really did in this pull request
1. Modified the code samples for the Tuple type, add more comments, trying to give a more detailed declaration for Tuple Type. e.g. The first time I read the doc, I'm quite confused how Tuple type actually works. I was thinking it's actually used for declaring some key-value pair, but actually, it's for declaring an array which each of the element has a specific type.
2. As mentioned above, the Tuple definition is outdated, now access the index outside of the defined one in a Tuple is not allowed anymore, and this will resolve #975 and another issue in Typescript repo https://github.com/Microsoft/TypeScript/issues/28894#issue-388536852
