### PR TITLE
Fix typo

### DIFF
--- a/pages/Iterators and Generators.md
+++ b/pages/Iterators and Generators.md
@@ -55,7 +55,7 @@ for (let pet of pets) {
 
 #### Targeting ES5 and ES3
 
-When targeting an ES5 or ES3, iterators are only allowed on values of `Array` type.
+When targeting an ES5 or ES3-compliant engine, iterators are only allowed on values of `Array` type.
 It is an error to use `for..of` loops on non-Array values, even if these non-Array values implement the `Symbol.iterator` property.
 
 The compiler will generate a simple `for` loop for a `for..of` loop, for instance:


### PR DESCRIPTION
For consistent grammar with the "Targeting ECMAScript 2015 and higher" section that follows.