### PR TITLE
Fix typo - Missing backtick in template string

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -43,7 +43,7 @@ let fullName: string = `Bob Bobbington`;
 let age: number = 37;
 let sentence: string = `Hello, my name is ${ fullName }.
 
-I'll be ${ age + 1 } years old next month.`;
+`I'll be ${ age + 1 } years old next month.`;
 ```
 
 This is equivalent to declaring `sentence` like so:


### PR DESCRIPTION
There is a missing backtick in the template string in the docs for Basic Types.md. This PR resolves that.