### PR TITLE
Fix error message when passing an object literal

### DIFF
--- a/pages/Interfaces.md
+++ b/pages/Interfaces.md
@@ -171,7 +171,7 @@ Object literals get special treatment and undergo *excess property checking* whe
 If an object literal has any properties that the "target type" doesn't have, you'll get an error:
 
 ```ts
-// error: 'colour' not expected in type 'SquareConfig'
+// error: Object literal may only specify known properties, but 'colour' does not exist in type 'SquareConfig'. Did you mean to write 'color'?
 let mySquare = createSquare({ colour: "red", width: 100 });
 ```
 


### PR DESCRIPTION
In the [Excess Property Checks](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks) section in the Interfaces page, when an object literal is passed with a wrong key, the error message currently in the documentation isn't as verbose as the one actually displayed by TypeScript.

This PR fixes the error message.
