### PR TITLE
replace hard-coded secret worst-practice in class accessor example

### DIFF
--- a/pages/Classes.md
+++ b/pages/Classes.md
@@ -302,14 +302,14 @@ if (employee.fullName) {
 }
 ```
 
-While allowing people to randomly set `fullName` directly is pretty handy, this might get us in trouble if people can change names on a whim.
+While allowing people to randomly set `fullName` directly is pretty handy, we may also want enforce some constraints when `fullName` is set.
 
-In this version, we check to make sure the user has a secret passcode available before we allow them to modify the employee.
-We do this by replacing the direct access to `fullName` with a `set` that will check the passcode.
-We add a corresponding `get` to allow the previous example to continue to work seamlessly.
+In this version, we add a setter that checks the length of the `newName` to make sure it's compatible with the max-length of our backing database field. If it isn't we throw an error notifying client code that something went wrong.
+
+To preserve existing functionality, we also add a simple getter that retrieves `fullName` unmodified.
 
 ```ts
-let passcode = "secret passcode";
+const fullNameMaxLength = 10;
 
 class Employee {
     private _fullName: string;
@@ -319,12 +319,11 @@ class Employee {
     }
 
     set fullName(newName: string) {
-        if (passcode && passcode == "secret passcode") {
-            this._fullName = newName;
+        if (newName && newName.length > fullNameMaxLength) {
+            throw new Error("fullName has a max length of " + fullNameMaxLength);
         }
-        else {
-            console.log("Error: Unauthorized update of employee!");
-        }
+        
+        this._fullName = newName;
     }
 }
 
@@ -335,7 +334,7 @@ if (employee.fullName) {
 }
 ```
 
-To prove to ourselves that our accessor is now checking the passcode, we can modify the passcode and see that when it doesn't match we instead get the message warning us we don't have access to update the employee.
+To prove to ourselves that our accessor is now checking the length of values, we can attempt to assign a name longer than 10 characters and verify that we get an error.
 
 A couple of things to note about accessors:
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
The accessor example for Classes.md in the handbook was checking an ambient plain-text password against a hard-coded literal in a property accessor. I just changed it to a simple string length validation so that there's no risk that there's no implied conflation of authentication and authorization, or of authorization implementation that'd never exist in a professional context. Have confirmed that it compiles and runs, and checked the contribution guidelines.

Thanks for the great docs! Sorry for there not being an issue for this - seemed like a little fix.