### PR TITLE
Update tuple docs to match post-2.7 behaviour

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -71,8 +71,7 @@ let list: Array<number> = [1, 2, 3];
 
 # [Tuple](Tuple)
 
-Tuple types allow you to express an array where the type of a fixed number of elements is known, but need not be the same.
-For example, you may want to represent a value as a pair of a `string` and a `number`:
+Tuple types allow you to express an array with a fixed number of elements whose types are known, but need not be the same. For example, you may want to represent a value as a pair of a `string` and a `number`:
 
 ```ts
 // Declare a tuple type
@@ -90,14 +89,12 @@ console.log(x[0].substr(1)); // OK
 console.log(x[1].substr(1)); // Error, 'number' does not have 'substr'
 ```
 
-When accessing an element outside the set of known indices, a union type is used instead:
+Accessing an element outside the set of known indices fails with an error:
 
 ```ts
-x[3] = "world"; // OK, 'string' can be assigned to 'string | number'
+x[3] = "world"; // Error, Property '3' does not exist on type '[string, number]'.
 
-console.log(x[5].toString()); // OK, 'string' and 'number' both have 'toString'
-
-x[6] = true; // Error, 'boolean' isn't 'string | number'
+console.log(x[5].toString()); // Error, Property '5' does not exist on type '[string, number]'.
 ```
 
 Union types are an advanced topic that we'll cover in a later chapter.


### PR DESCRIPTION
Tuples were changed in 2.7 (see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html , section "Fixed Length Tuples") to not allow assignments outside of the declared indexes. This commit updates the handbook docs to match this behaviour.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
