### PR TITLE
[doc] typo in Declaration Merging

### DIFF
--- a/pages/Declaration Merging.md
+++ b/pages/Declaration Merging.md
@@ -248,13 +248,13 @@ For information on mimicking class merging, see the [Mixins in TypeScript](./Mix
 Although JavaScript modules do not support merging, you can patch existing objects by importing and then updating them.
 Let's look at a toy Observable example:
 
-```js
-// observable.js
+```ts
+// observable.ts
 export class Observable<T> {
     // ... implementation left as an exercise for the reader ...
 }
 
-// map.js
+// map.ts
 import { Observable } from "./observable";
 Observable.prototype.map = function (f) {
     // ... another exercise for the reader


### PR DESCRIPTION
Updating [https://www.typescriptlang.org/docs/handbook/declaration-merging.html](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)

`observable.js` should be `observable.ts` since it includes TypeScript code

```ts
export class Observable<T>
```

and the file is referenced below with `// observable.ts stays the same` which make it clear that we expect the file to end with `.ts`