### PR TITLE
Make the React & Webpack tutorial cross-platform compatible

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -29,7 +29,10 @@ Any components that we write will go in the `src/components` folder.
 Let's scaffold this out:
 
 ```shell
-mkdir -p src/components
+mkdir src
+cd src
+mkdir components
+cd ..
 ```
 
 Webpack will eventually generate the `dist` directory for us.


### PR DESCRIPTION
mkdir doesn't support -p on Windows. This is a cross-platform way of creating the folder structure.