### PR TITLE
Resolve large font size in handbook documentation

### DIFF
--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -268,19 +268,20 @@ This tells the compiler for any module import that matches the pattern `"*"` (i.
 
 Following this logic, the compiler will attempt to resolve the two imports as such:
 
-* import 'folder1/file2'
-  1. pattern '*' is matched and wildcard captures the whole module name
-  2. try first substitution in the list: '*' -> `folder1/file2`
-  3. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/folder1/file2.ts`.
-  4. File exists. Done.
-* import 'folder2/file3'
-  1. pattern '*' is matched and wildcard captures the whole module name
-  2. try first substitution in the list: '*' -> `folder2/file3`
-  3. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/folder2/file3.ts`.
-  4. File does not exist, move to the second substitution
-  5. second substitution 'generated/*' -> `generated/folder2/file3`
-  6. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/generated/folder2/file3.ts`.
-  7. File exists. Done.
+import 'folder1/file2':
+ 1. pattern '*' is matched and wildcard captures the whole module name
+ 2. try first substitution in the list: '*' -> `folder1/file2`
+ 3. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/folder1/file2.ts`.
+ 4. File exists. Done.
+
+import 'folder2/file3':
+ 1. pattern '*' is matched and wildcard captures the whole module name
+ 2. try first substitution in the list: '*' -> `folder2/file3`
+ 3. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/folder2/file3.ts`.
+ 4. File does not exist, move to the second substitution
+ 5. second substitution 'generated/*' -> `generated/folder2/file3`
+ 6. result of substitution is non-relative name - combine it with *baseUrl* -> `projectRoot/generated/folder2/file3.ts`.
+ 7. File exists. Done.
 
 ### Virtual Directories with `rootDirs`
 


### PR DESCRIPTION
The following address was showing a large font for import resolutions:

https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping

Instead of using an ordered list within a bullet point, bring the
subject line to the parent level and then use an ordered list.