### PR TITLE
fix: typo in jsdoc @template example

### DIFF
--- a/pages/Type Checking JavaScript Files.md
+++ b/pages/Type Checking JavaScript Files.md
@@ -596,7 +596,7 @@ You can declare generic types with the `@template` tag:
 ```js
 /**
  * @template T
- * @param {T} p1 - A generic parameter that flows through to the return type
+ * @param {T} x - A generic parameter that flows through to the return type
  * @return {T}
  */
 function id(x){ return x }


### PR DESCRIPTION
The param name is incorrect.

Currently says `p1` instead of the function's param `x`

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->
