### PR TITLE
Removes a link out to the wiki in the JS page

### DIFF
--- a/pages/Type Checking JavaScript Files.md
+++ b/pages/Type Checking JavaScript Files.md
@@ -24,7 +24,7 @@ x = 0;      // OK
 x = false;  // Error: boolean is not assignable to number
 ```
 
-You can find the full list of supported JSDoc patterns in the [JSDoc support in JavaScript documentation](https://github.com/Microsoft/TypeScript/wiki/JSDoc-support-in-JavaScript).
+You can find the full list of supported JSDoc patterns [below](#supported-jsdoc).
 
 ## Properties are inferred from assignments in class bodies
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/32589