### PR TITLE
adding missing closing curly braces in modules handbook page

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -44,6 +44,7 @@ export class ZipCodeValidator implements StringValidator {
     isAcceptable(s: string) {
         return s.length === 5 && numberRegexp.test(s);
     }
+}
 ```
 
 ## Export statements


### PR DESCRIPTION
noticed a typo while reading the handbook. thought to send a PR.