### PR TITLE
remove unnecessary space from modules handbook document

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -195,7 +195,7 @@ let strings = ["Hello", "98052", "101"];
 
 // Use function validate
 strings.forEach(s => {
-  console.log(`"${s}" ${validate(s) ? " matches" : " does not match"}`);
+  console.log(`"${s}" ${validate(s) ? "matches" : "does not match"}`);
 });
 ```
 


### PR DESCRIPTION
in backticks string, there is already space defined after `"{s}"` so there no need for additional space in the subsequent conditional expression

previous behavior:

```js
> function validate(s) { return s.length === 5 }
undefined
> ["Hello", "98052", "101"].forEach(s => { console.log(`"${s}" ${validate(s) ? " matches" : " does not match"}`); })
"Hello"  matches
"98052"  matches
"101"  does not match
undefined
```