### PR TITLE
Remove a comment about union types in tuple doc

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -202,7 +202,8 @@ That means you can assign `null` and `undefined` to something like `number`.
 However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `any` and their respective types (the one exception being that `undefined` is also assignable to `void`).
 This helps avoid *many* common errors.
 In cases where you want to pass in either a `string` or `null` or `undefined`, you can use the union type `string | null | undefined`.
-Once again, more on union types later on.
+
+Union types are an advanced topic that we'll cover in a later chapter.
 
 > As a note: we encourage the use of `--strictNullChecks` when possible, but for the purposes of this handbook, we will assume it is turned off.
 

--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -97,8 +97,6 @@ x[3] = "world"; // Error, Property '3' does not exist on type '[string, number]'
 console.log(x[5].toString()); // Error, Property '5' does not exist on type '[string, number]'.
 ```
 
-Union types are an advanced topic that we'll cover in a later chapter.
-
 # Enum
 
 A helpful addition to the standard set of datatypes from JavaScript is the `enum`.


### PR DESCRIPTION
As a result of #1030, the comment about union type in tuple doc is no longer necessary.