### PR TITLE
Emphasize that void accepts null unless strictNullChecks

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -179,10 +179,11 @@ function warnUser(): void {
 }
 ```
 
-Declaring variables of type `void` is not useful because you can only assign `undefined` or `null` to them:
+Declaring variables of type `void` is not useful because you can only assign `null` (only if `--strictNullChecks` is not specified, see next section) or `undefined` to them:
 
 ```ts
 let unusable: void = undefined;
+unusable = null; // OK if `--strictNullChecks` is not given
 ```
 
 # Null and Undefined


### PR DESCRIPTION
Though this specification was written in #1053, I still got confused when I read the section "Void" -- "`null` can't be assigned to `void` on TypeScript playground... is document wrong?"
And I had stayed confused for 10 minutes until I carefully read the next section (Null and Undefined).

This changes remove the time window of confusing between these two sections, complementing #1053.
