### PR TITLE
Watchify: log compilation errors

### DIFF
--- a/pages/tutorials/Gulp.md
+++ b/pages/tutorials/Gulp.md
@@ -300,6 +300,7 @@ gulp.task('copy-html', function () {
 function bundle() {
     return watchedBrowserify
         .bundle()
+        .on('error', fancy_log)
         .pipe(source('bundle.js'))
         .pipe(gulp.dest('dist'));
 }


### PR DESCRIPTION
When TypeScript fails to compile, Watchify simply creates an almost-empty bundle. With this change, it will also log TypeScript's error. Kudos to @blakeembrey for the solution.

Fixes https://github.com/Microsoft/TypeScript/issues/13700.