### PR TITLE
Adds a note about `strictFunctionTypes` to type compatibility

### DIFF
--- a/pages/Type Compatibility.md
+++ b/pages/Type Compatibility.md
@@ -135,6 +135,8 @@ listenEvent(EventType.Mouse, ((e: MouseEvent) => console.log(e.x + "," + e.y)) a
 listenEvent(EventType.Mouse, (e: number) => console.log(e));
 ```
 
+You can have TypeScript raise errors when this happens via the compiler flag `strictFunctionTypes`.
+
 ## Optional Parameters and Rest Parameters
 
 When comparing functions for compatibility, optional and required parameters are interchangeable.

--- a/pages/release notes/TypeScript 3.1.md
+++ b/pages/release notes/TypeScript 3.1.md
@@ -18,7 +18,7 @@ So the resulting type `PromiseCoordinate` ends up with the type `[Promise<number
 
 # Properties declarations on functions
 
-TypeScript 3.1 brings the ability to define properties on function declarations and `const`-declared functons, simply by assigning to properties on these functions in the same scope.
+TypeScript 3.1 brings the ability to define properties on function declarations and `const`-declared functions, simply by assigning to properties on these functions in the same scope.
 This allows us to write canonical JavaScript code without resorting to `namespace` hacks.
 For example:
 


### PR DESCRIPTION
Came out of work on the examples