### PR TITLE
Fix typo in JSX Class Component

### DIFF
--- a/pages/JSX.md
+++ b/pages/JSX.md
@@ -218,7 +218,7 @@ function MyFactoryFunction() {
 // use a call signature
 var myComponent = MyFactoryFunction();
 
-// element class type => FactoryFunction
+// element class type => MyFactoryFunction
 // element instance type => { render: () => void }
 ```
 


### PR DESCRIPTION
`FactoryFunction` should be either `MyFactoryFunction` to match the previously defined function or just generic `factory function`