### PR TITLE
Remove elusive paragraph from TS 3.6 release notes

### DIFF
--- a/pages/release notes/TypeScript 3.6.md
+++ b/pages/release notes/TypeScript 3.6.md
@@ -315,10 +315,6 @@ For the most part, TypeScript would default to auto-importing using ECMAScript m
 TypeScript 3.6 is now a bit smarter about looking at your existing imports before deciding on how to auto-import other modules.
 You can [see more details in the original pull request here](https://github.com/microsoft/TypeScript/pull/32684).
 
-## `await` Completions on Promises
-
-In TypeScript 3.6, completions on an 
-
 ## New TypeScript Playground
 
 The TypeScript playground has received a much-needed refresh with handy new functionality!


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #1116
I've compared release notes to official announce in [TypeScript dev blog on Microsoft's site](https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/)
These phrases are absent, so need to be removed