### PR TITLE
Adds a release index redirect to the overview page

### DIFF
--- a/pages/release notes/index.html
+++ b/pages/release notes/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="description" content="Release notes for TS">
+<meta name="keywords" content="TypeScript, TS, releases, release">
+<title>TypeScript Release Notes</title>
+<script>
+    window.location.replace("./Overview.html");
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/31983#issuecomment-503666822 

I added the overall release notes when the wiki started to stop rendering, this just accepts the URL at https://www.typescriptlang.org/docs/handbook/release-notes

/cc @wongmjane