### PR TITLE
Add `bigint` to primitive list

### DIFF
--- a/pages/Basic Types.md
+++ b/pages/Basic Types.md
@@ -239,7 +239,7 @@ function infiniteLoop(): never {
 
 # [Object](Object)
 
-`object` is a type that represents the non-primitive type, i.e. anything that is not `number`, `string`, `boolean`, `symbol`, `null`, or `undefined`.
+`object` is a type that represents the non-primitive type, i.e. anything that is not `number`, `string`, `boolean`, `bigint`, `symbol`, `null`, or `undefined`.
 
 With `object` type, APIs like `Object.create` can be better represented. For example:
 


### PR DESCRIPTION
`bigint` is a primitive since is not assignable to `object`. Not sure if we want this here though since there is no description for newer types such as `bigint` or `unknown` in "Basic Types.md". [`bigint` is introduced in TS@3.2 page](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html).

```ts
const foo: object = BigInt(100); // Type 'bigint' is not assignable to type 'object'.ts(2322)
```

https://mariusschulz.com/blog/the-object-type-in-typescript