### PR TITLE
Expanded structure docs for project references

### DIFF
--- a/pages/Project References.md
+++ b/pages/Project References.md
@@ -184,9 +184,9 @@ If your solution is like this, you can continue to use `msbuild` with `tsc -p` a
 With more `tsconfig.json` files, you'll usually want to use [Configuration file inheritance](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) to centralize your common compiler options.
 This way you can change a setting in one file rather than having to edit multiple files.
 
-Another good practice is to have a "solution" `tsconfig.json` file that simply has `references` to all of your leaf-node projects.
+Another good practice is to have a "solution" `tsconfig.json` file that simply has `references` to all of your leaf-node projects and sets `files` to an empty array (otherwise the solution file will cause double compilation of files). Note that starting with 3.0, it is no longer an error to have an empty `files` array if you have at least one `reference` in a `tsconfig.json` file.
+
 This presents a simple entry point; e.g. in the TypeScript repo we simply run `tsc -b src` to build all endpoints because we list all the subprojects in `src/tsconfig.json`
-Note that starting with 3.0, it is no longer an error to have an empty `files` array if you have at least one `reference` in a `tsconfig.json` file.
 
 You can see these patterns in the TypeScript repo - see `src/tsconfig_base.json`, `src/tsconfig.json`, and `src/tsc/tsconfig.json` as key examples.
 


### PR DESCRIPTION
* Make it clear files should be empty rather than indirectly applied

Based on answer in https://github.com/microsoft/TypeScript/issues/34889