### PR TITLE
Fix the playground link under Recursive Type Aliases section

### DIFF
--- a/pages/release notes/TypeScript 3.7.md
+++ b/pages/release notes/TypeScript 3.7.md
@@ -351,7 +351,7 @@ As with assertion functions, you can [read up more at the same pull request](htt
 
 ## (More) Recursive Type Aliases
 
-[Playground](/play/#example/recursive-type-references
+[Playground](/play/#example/recursive-type-references)
 
 Type aliases have always had a limitation in how they could be "recursively" referenced.
 The reason is that any use of a type alias needs to be able to substitute itself with whatever it aliases.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

This fixes the playground link under the Recursive Type Aliases section in the Typescript 3.7 Release Notes
