### PR TITLE
docs(advanced types): fix typo in sentence 

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -588,7 +588,7 @@ function rollDice(): 1 | 2 | 3 | 4 | 5 | 6 {
 }
 ```
 
-These are seldom written explicitly, they can be useful when narrowing can catch bugs:
+These are seldom written explicitly, but they can be useful when narrowing issues and can catch bugs:
 
 ```ts
 function foo(x: number) {


### PR DESCRIPTION
Fix typo in sentence. 

Fixes N/A
