### PR TITLE
Renaming `function f<T>` to `function foo<T>`

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -1084,7 +1084,7 @@ interface Foo {
     propB: boolean;
 }
 
-declare function f<T>(x: T): T extends Foo ? string : number;
+declare function foo<T>(x: T): T extends Foo ? string : number;
 
 function foo<U>(x: U) {
     // Has type 'U extends Foo ? string : number'


### PR DESCRIPTION
I was reading this page and I believe the function name in the declaration should be `foo` to match the implementation and the following paragraph.

