### PR TITLE
Add ConstructorParameters<T> to Utility Types

### DIFF
--- a/pages/Utility Types.md
+++ b/pages/Utility Types.md
@@ -13,6 +13,7 @@ TypeScript provides several utility types to facilitate common type transformati
 * [`Extract<T,U>`](#extracttu)
 * [`NonNullable<T>`](#nonnullablet)
 * [`Parameters<T>`](#parameterst)
+* [`ConstructorParameters<T>`](#constructorparameterst)
 * [`ReturnType<T>`](#returntypet)
 * [`InstanceType<T>`](#instancetypet)
 * [`Required<T>`](#requiredt)
@@ -182,6 +183,18 @@ type T5 = Parameters<any>;  // unknown[]
 type T6 = Parameters<never>;  // any
 type T7 = Parameters<string>;  // Error
 type T8 = Parameters<Function>;  // Error
+```
+
+# `ConstructorParameters<T>`
+
+The `ConstructorParameters<T>` type lets us extract all parameter types of a constructor function type. It produces a tuple type with all the parameter types (or the type `never` if `T` is not a function).
+
+##### Example
+
+```ts
+type T0 = ConstructorParameters<ErrorConstructor>;  // [(string | undefined)?]
+type T1 = ConstructorParameters<FunctionConstructor>;  // string[]
+type T2 = ConstructorParameters<RegExpConstructor>;  // [string, (string | undefined)?]
 ```
 
 # `ReturnType<T>`


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes # @orta I added a missing Utility Type as per your request on my blog here: https://www.elsewebdevelopment.com/typescript-3-7-utility-types-printable-pdf-cheat-sheet/ .Someone else beat me to the `Parameters<T>`. I hope it is OK, cheers.
