### PR TITLE
tsconfig.json: extends path allows Node resolution

### DIFF
--- a/pages/tutorials/tsconfig.json.md
+++ b/pages/tutorials/tsconfig.json.md
@@ -143,7 +143,7 @@ If you use an `import "foo"` statement, for instance, TypeScript may still look 
 A `tsconfig.json` file can inherit configurations from another file using the `extends` property.
 
 The `extends` is a top-level property in `tsconfig.json` (alongside `compilerOptions`, `files`, `include`, and `exclude`).
-`extends`' value is a string containing a path to another configuration file to inherit from.
+`extends`' value is a string containing a path to another configuration file to inherit from. The path may use Node.js style resolution.
 
 The configuration from the base file are loaded first, then overridden by those  in the inheriting config file.
 If a circularity is encountered, we report an error.

--- a/pages/tutorials/tsconfig.json.md
+++ b/pages/tutorials/tsconfig.json.md
@@ -143,7 +143,8 @@ If you use an `import "foo"` statement, for instance, TypeScript may still look 
 A `tsconfig.json` file can inherit configurations from another file using the `extends` property.
 
 The `extends` is a top-level property in `tsconfig.json` (alongside `compilerOptions`, `files`, `include`, and `exclude`).
-`extends`' value is a string containing a path to another configuration file to inherit from. The path may use Node.js style resolution.
+`extends`' value is a string containing a path to another configuration file to inherit from.
+The path may use Node.js style resolution.
 
 The configuration from the base file are loaded first, then overridden by those  in the inheriting config file.
 If a circularity is encountered, we report an error.


### PR DESCRIPTION
Add a phrase indicating that the `extends` option may use Node.js tyle module resolution.

This was surprising to me based on the current language in the handbook, but observed behavior and source seem to indicate that Node.js module resolution is allowed:

https://github.com/microsoft/TypeScript/blob/7c14aff09383f3814d7aae1406b5b2707b72b479/src/compiler/commandLineParser.ts#L2402-L2406

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

