### PR TITLE
Fix Parameter Utility documented return types

### DIFF
--- a/pages/Utility Types.md
+++ b/pages/Utility Types.md
@@ -180,9 +180,9 @@ declare function f1(arg: { a: number, b: string }): void
 type T0 = Parameters<() => string>;  // []
 type T1 = Parameters<(s: string) => void>;  // [string]
 type T2 = Parameters<(<T>(arg: T) => T)>;  // [unknown]
-type T4 = Parameters<typeof f1>;  // { a: number, b: string }
+type T4 = Parameters<typeof f1>;  // [{ a: number, b: string }]
 type T5 = Parameters<any>;  // unknown[]
-type T6 = Parameters<never>;  // any
+type T6 = Parameters<never>;  // never
 type T7 = Parameters<string>;  // Error
 type T8 = Parameters<Function>;  // Error
 ```


### PR DESCRIPTION
The return types commented next the `Parameter` Utility type code snippet had 2 typo's in it.