### PR TITLE
Remove references to changes from TypeScript 1.5 in the modules docs

### DIFF
--- a/pages/Modules.md
+++ b/pages/Modules.md
@@ -1,8 +1,3 @@
-> **A note about terminology:**
-It's important to note that in TypeScript 1.5, the nomenclature has changed.
-"Internal modules" are now "namespaces".
-"External modules" are now simply "modules", as to align with [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/)'s terminology, (namely that `module X {` is equivalent to the now-preferred `namespace X {`).
-
 # Introduction
 
 Starting with ECMAScript 2015, JavaScript has a concept of modules. TypeScript shares this concept.

--- a/pages/Namespaces and Modules.md
+++ b/pages/Namespaces and Modules.md
@@ -1,38 +1,34 @@
-> **A note about terminology:**
-It's important to note that in TypeScript 1.5, the nomenclature has changed.
-"Internal modules" are now "namespaces".
-"External modules" are now simply "modules", as to align with [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/)'s terminology, (namely that `module X {` is equivalent to the now-preferred `namespace X {`).
-
 # Introduction
 
-This post outlines the various ways to organize your code using namespaces and modules in TypeScript.
+This post outlines the various ways to organize your code using modules and namespaces in TypeScript.
 We'll also go over some advanced topics of how to use namespaces and modules, and address some common pitfalls when using them in TypeScript.
 
-See the [Modules](./Modules.md) documentation for more information about modules.
-See the [Namespaces](./Namespaces.md) documentation for more information about namespaces.
+See the [Modules](./Modules.md) documentation for more information about ES Modules.
+See the [Namespaces](./Namespaces.md) documentation for more information about TypeScript namespaces.
 
-# Using Namespaces
-
-Namespaces are simply named JavaScript objects in the global namespace.
-This makes namespaces a very simple construct to use.
-They can span multiple files, and can be concatenated using `--outFile`.
-Namespaces can be a good way to structure your code in a Web Application, with all dependencies included as `<script>` tags in your HTML page.
-
-Just like all global namespace pollution, it can be hard to identify component dependencies, especially in a large application.
+Note: In _very_ old versions of TypeScript namespaces were called 'Internal Modules', these pre-date JavaScript module systems.
 
 # Using Modules
 
-Just like namespaces, modules can contain both code and declarations.
-The main difference is that modules *declare* their dependencies.
+Modules can contain both code and declarations.
 
-Modules also have a dependency on a module loader (such as CommonJs/Require.js).
-For a small JS application this might not be optimal, but for larger applications, the cost comes with long term modularity and maintainability benefits.
+Modules also have a dependency on a module loader (such as CommonJs/Require.js) or a runtime which supports ES Modules.
 Modules provide for better code reuse, stronger isolation and better tooling support for bundling.
 
 It is also worth noting that, for Node.js applications, modules are the default and the recommended approach to structure your code.
 
 Starting with ECMAScript 2015, modules are native part of the language, and should be supported by all compliant engine implementations.
 Thus, for new projects modules would be the recommended code organization mechanism.
+
+# Using Namespaces
+
+Namespaces are a TypeScript-specific way to organize code.  
+Namespaces are simply named JavaScript objects in the global namespace.
+This makes namespaces a very simple construct to use.
+Unlike modules, they can span multiple files, and can be concatenated using `--outFile`.
+Namespaces can be a good way to structure your code in a Web Application, with all dependencies included as `<script>` tags in your HTML page.
+
+Just like all global namespace pollution, it can be hard to identify component dependencies, especially in a large application.
 
 # Pitfalls of Namespaces and Modules
 

--- a/pages/Namespaces.md
+++ b/pages/Namespaces.md
@@ -16,18 +16,10 @@
 [Working with Other JavaScript Libraries](#working-with-other-javascript-libraries)
 * [Ambient Namespaces](#ambient-namespaces)
 
-> **A note about terminology:**
-It's important to note that in TypeScript 1.5, the nomenclature has changed.
-"Internal modules" are now "namespaces".
-"External modules" are now simply "modules", as to align with [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/)'s terminology, (namely that `module X {` is equivalent to the now-preferred `namespace X {`).
-
 # Introduction
 <b><a href="#table-of-contents">↥ back to top</a></b>
 
-This post outlines the various ways to organize your code using namespaces (previously "internal modules") in TypeScript.
-As we alluded in our note about terminology, "internal modules" are now referred to as "namespaces".
-Additionally, anywhere the `module` keyword was used when declaring an internal module, the `namespace` keyword can and should be used instead.
-This avoids confusing new users by overloading them with similarly named terms.
+This post outlines the various ways to organize your code using namespaces in TypeScript.
 
 # First steps
 <b><a href="#table-of-contents">↥ back to top</a></b>
@@ -36,7 +28,6 @@ Let's start with the program we'll be using as our example throughout this page.
 We've written a small set of simplistic string validators, as you might write to check a user's input on a form in a webpage or check the format of an externally-provided data file.
 
 ## Validators in a single file
-<b><a href="#table-of-contents">↥ back to top</a></b>
 
 ```ts
 interface StringValidator {
@@ -76,7 +67,6 @@ for (let s of strings) {
 ```
 
 # Namespacing
-<b><a href="#table-of-contents">↥ back to top</a></b>
 
 As we add more validators, we're going to want to have some kind of organization scheme so that we can keep track of our types and not worry about name collisions with other objects.
 Instead of putting lots of different names into the global namespace, let's wrap up our objects into a namespace.
@@ -87,7 +77,6 @@ Conversely, the variables `lettersRegexp` and `numberRegexp` are implementation 
 In the test code at the bottom of the file, we now need to qualify the names of the types when used outside the namespace, e.g. `Validation.LettersOnlyValidator`.
 
 ## Namespaced Validators
-<b><a href="#table-of-contents">↥ back to top</a></b>
 
 ```ts
 namespace Validation {


### PR DESCRIPTION
Does some minor spring cleaning after I spotted this Reddit thread: https://www.reddit.com/r/typescript/comments/ewjhiy/typescript_i_love_you_but_this_documentation_is/

- I tried to orient folks to understanding that namespaces are a TS thing
- I re-oriented the order in which they're presented to give modules first
- I removed the references to the 1.5 transition 