### PR TITLE
Edit declaration code example to match spec

### DIFF
--- a/pages/declaration files/By Example.md
+++ b/pages/declaration files/By Example.md
@@ -168,7 +168,7 @@ greet(new MyGreeter());
 You can use a type alias to make a shorthand for a type:
 
 ```ts
-type GreetingLike = string | (() => string) | MyGreeter;
+type GreetingLike = string | (() => string) | Greeter;
 
 declare function greet(g: GreetingLike): void;
 ```


### PR DESCRIPTION
Change `MyGreeter` to `Greeter` in type alias example.

Fixes #1291
