### PR TITLE
Update TypeScript 3.8.md - missing backquote

### DIFF
--- a/pages/release notes/TypeScript 3.8.md
+++ b/pages/release notes/TypeScript 3.8.md
@@ -206,7 +206,7 @@ For more information about the implementation, you can [check out the original p
 We've already received many questions on which type of privates you should use as a TypeScript user: most commonly, "should I use the `private` keyword, or ECMAScript's hash/pound (`#`) private fields?"
 It depends!
 
-When it comes to properties, TypeScript's `private` modifiers are fully erased - that means that at runtime, it acts entirely like a normal property and there's no way to tell that it was declared with a `private modifier.
+When it comes to properties, TypeScript's `private` modifiers are fully erased - that means that at runtime, it acts entirely like a normal property and there's no way to tell that it was declared with a `private` modifier.
 When using the `private` keyword, privacy is only enforced at compile-time/design-time, and for JavaScript consumers it's entirely intent-based.
 
 ```ts


### PR DESCRIPTION
missing backquote : `private => `private`
