### PR TITLE
Remove deprecated awesome-typescript-loader from docs

### DIFF
--- a/pages/Integrating with Build Tools.md
+++ b/pages/Integrating with Build Tools.md
@@ -228,10 +228,6 @@ module.exports = {
 
 See [more details on ts-loader here](https://www.npmjs.com/package/ts-loader).
 
-Alternatives:
-
-* [awesome-typescript-loader](https://www.npmjs.com/package/awesome-typescript-loader)
-
 # MSBuild
 
 Update project file to include locally installed `Microsoft.TypeScript.Default.props` (at the top) and `Microsoft.TypeScript.targets` (at the bottom) files:

--- a/pages/tutorials/Migrating from JavaScript.md
+++ b/pages/tutorials/Migrating from JavaScript.md
@@ -85,11 +85,11 @@ You can read more there.
 ## Webpack
 
 Webpack integration is pretty simple.
-You can use `awesome-typescript-loader`, a TypeScript loader, combined with `source-map-loader` for easier debugging.
+You can use `ts-loader`, a TypeScript loader.
 Simply run
 
 ```shell
-npm install awesome-typescript-loader source-map-loader
+npm install --save-dev ts-loader
 ```
 
 and merge in options from the following into your `webpack.config.js` file:
@@ -97,12 +97,6 @@ and merge in options from the following into your `webpack.config.js` file:
 ```js
 module.exports = {
     entry: "./src/index.ts",
-    output: {
-        filename: "./dist/bundle.js",
-    },
-
-    // Enable sourcemaps for debugging webpack's output.
-    devtool: "source-map",
 
     resolve: {
         // Add '.ts' and '.tsx' as resolvable extensions.
@@ -110,26 +104,26 @@ module.exports = {
     },
 
     module: {
-        loaders: [
-            // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { test: /\.tsx?$/, loader: "awesome-typescript-loader" }
+        rules: [
+            {
+                // // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
         ],
+    },
 
-        preLoaders: [
-            // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { test: /\.js$/, loader: "source-map-loader" }
-        ]
+    output: {
+        filename: "bundle.js",
+        path: path.resolve(__dirname, "dist"),
     },
 
     // Other options...
 };
 ```
 
-It's important to note that awesome-typescript-loader will need to run before any other loader that deals with `.js` files.
-
-The same goes for [ts-loader](https://github.com/TypeStrong/ts-loader), another TypeScript loader for Webpack.
-You can read more about the differences between the two [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader).
-
+You can read more about ts-loader [here](https://github.com/TypeStrong/ts-loader).
 You can see an example of using Webpack in our [tutorial on React and Webpack](./React%20&%20Webpack.md).
 
 # Moving to TypeScript Files


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #1285 
