### PR TITLE
Fix description of Exclude and Extract types

### DIFF
--- a/pages/Utility Types.md
+++ b/pages/Utility Types.md
@@ -137,7 +137,7 @@ const todo: TodoPreview = {
 
 # `Exclude<T,U>`
 
-Constructs a type by excluding from `T` all properties that are assignable to `U`.
+Constructs a type by excluding from `T` all types that are assignable to `U`.
 
 ##### Example
 
@@ -149,7 +149,7 @@ type T2 = Exclude<string | number | (() => void), Function>;  // string | number
 
 # `Extract<T,U>`
 
-Constructs a type by extracting from `T` all properties that are assignable to `U`.
+Constructs a type by extracting from `T` all types that are assignable to `U`.
 
 ##### Example
 


### PR DESCRIPTION
The previous description was:

> Constructs a type by excluding/extracting from `T` all properties that are assignable to `U`.

This sounds to me like Exclude and Extract would do this:

```typescript
interface Person {
  id: number;
  name: string;
}

type NumbersOnly = Extract<Person, number>;  // { id: number }
type NoNumbers = Exclude<Person, number>;    // { name: string }
```

I think "Constructs a type by excluding/extracting from `T` all types that are assignable to `U`," more clearly describes removing types from the union, rather than affecting its properties.