### PR TITLE
Fix typo

### DIFF
--- a/pages/Type Compatibility.md
+++ b/pages/Type Compatibility.md
@@ -30,7 +30,7 @@ TypeScript's type system allows certain operations that can't be known at compil
 
 # Starting out
 
-The basic rule for TypeScript's structural type system is that `x` is compatible with `y` if `y` has at least the same members as `x`. For example:
+The basic rule for TypeScript's structural type system is that `y` is compatible with `x` if `y` has at least the same members as `x`. For example:
 
 ```ts
 interface Named {


### PR DESCRIPTION
The handbook reads

> `x` is compatible with `y` if `y` has at least the same members as `x`

I believe the types should be flipped

> `y` is compatible with `x` if `y` has at least the same members as `x`

Because compatibility is viewed from the point of view of the type that is assigned not from the point of view of the type being assigned to.

An example:

```typescript
interface Named {
  name: string;
}

class Person {
  name: string;
  age: number;
}

let x: Named;
let y = new Person();

x = y; // valid, since y is compatible with x
y = x; // invalid, since x is not compatible with y
```

Mathematically speaking, `y` is compatible with `x` iff ![x \subseteq y](https://render.githubusercontent.com/render/math?math=x%20%5Csubseteq%20y), instead of ![y \subseteq x](https://render.githubusercontent.com/render/math?math=y%20%5Csubseteq%20x) like currently stated.