### PR TITLE
Prepare the repo for archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# TypeScript-Handbook Repo Deprecated
+
+The handbook has moved into the new TypeScript website repo, you can find the revised and updated handbook pages in [`/packages/handbook-v1`](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/handbook-v1) in that repo.
+
+---
+
 # TypeScript-Handbook
 
 [![Build Status](https://travis-ci.org/Microsoft/TypeScript-Handbook.svg)](https://travis-ci.org/Microsoft/TypeScript-Handbook)


### PR DESCRIPTION
With the handbook living natively in the site repo now, it's time to close up this repo and call it issue bankruptcy. Luckily archiving a repo turns the issues read-only, so we don't loose any historical info in the process.