### PR TITLE
Fix typo in article "Type Compatibility"

### DIFF
--- a/pages/Type Compatibility.md
+++ b/pages/Type Compatibility.md
@@ -105,7 +105,7 @@ x = y; // OK
 y = x; // Error, because x() lacks a location property
 ```
 
-The type system enforces that the source function's return type be a subtype of the target type's return type.
+The type system enforces that the target function's return type be a subtype of the source type's return type.
 
 ## Function Parameter Bivariance
 


### PR DESCRIPTION
I believe that in the computing the common usage of the term "source" is an input for some "target". So in the example of the section "Comparing two functions" "source" and "target" should be swapped.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->
