### PR TITLE
Fix broken link on a website

### DIFF
--- a/pages/Iterators and Generators.md
+++ b/pages/Iterators and Generators.md
@@ -1,6 +1,6 @@
 # Iterables
 
-An object is deemed iterable if it has an implementation for the [`Symbol.iterator`](Symbols.md#symboliterator) property.
+An object is deemed iterable if it has an implementation for the [`Symbol.iterator`](./Symbols.md#symboliterator) property.
 Some built-in types like `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. have their `Symbol.iterator` property already implemented.
 `Symbol.iterator` function on an object is responsible for returning the list of values to iterate on.
 


### PR DESCRIPTION
Fixes #
https://www.typescriptlang.org/docs/handbook/Symbols.md#symboliterator
broken link, fix by example of types link construction, [here](https://www.typescriptlang.org/docs/handbook/enums.html#union-enums-and-enum-member-types)