### PR TITLE
Interfaces vs. Type Aliases hover update

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -516,7 +516,7 @@ As we mentioned, type aliases can act sort of like interfaces; however, there ar
 
 One difference is that interfaces create a new name that is used everywhere.
 Type aliases don't create a new name &mdash; for instance, error messages won't use the alias name.
-In the code below, hovering over `interfaced` in an editor will show that it returns an `Interface`, but will show that `aliased` returns object literal type.
+In the code below, hovering over `Alias` in the return type of the function in an editor will show that it returns an `Interface`, but doing the same for `Interface` will show that it returns an object literal type.
 
 ```ts
 type Alias = { num: number }


### PR DESCRIPTION
I tried the original method from and it didn't work in any TS from 3.33 to 3.83.

Hovering the return type, however, produces the intended result.