### PR TITLE
Add readonly for React Props interface

### DIFF
--- a/pages/tutorials/React & Webpack.md
+++ b/pages/tutorials/React & Webpack.md
@@ -115,7 +115,7 @@ First, create a file named `Hello.tsx` in `src/components` and write the followi
 ```ts
 import * as React from "react";
 
-export interface HelloProps { compiler: string; framework: string; }
+export interface HelloProps { readonly compiler: string; readonly framework: string; }
 
 export const Hello = (props: HelloProps) => <h1>Hello from {props.compiler} and {props.framework}!</h1>;
 ```
@@ -125,7 +125,7 @@ Note that while this example uses [function components](https://reactjs.org/docs
 ```ts
 import * as React from "react";
 
-export interface HelloProps { compiler: string; framework: string; }
+export interface HelloProps { readonly compiler: string; readonly framework: string; }
 
 // 'HelloProps' describes the shape of props.
 // State is never set so we use the '{}' type.

--- a/pages/tutorials/React.md
+++ b/pages/tutorials/React.md
@@ -112,8 +112,8 @@ We'll write a `Hello.tsx`:
 import * as React from 'react';
 
 export interface Props {
-  name: string;
-  enthusiasmLevel?: number;
+  readonly name: string;
+  readonly enthusiasmLevel?: number;
 }
 
 function Hello({ name, enthusiasmLevel = 1 }: Props) {
@@ -362,8 +362,8 @@ For this, we can create a file called `src/types/index.tsx` which will contain d
 // src/types/index.tsx
 
 export interface StoreState {
-    languageName: string;
-    enthusiasmLevel: number;
+    readonly languageName: string;
+    readonly enthusiasmLevel: number;
 }
 ```
 
@@ -393,11 +393,11 @@ Next, we'll create a set of actions and functions that can create these actions 
 import * as constants from '../constants'
 
 export interface IncrementEnthusiasm {
-    type: constants.INCREMENT_ENTHUSIASM;
+    readonly type: constants.INCREMENT_ENTHUSIASM;
 }
 
 export interface DecrementEnthusiasm {
-    type: constants.DECREMENT_ENTHUSIASM;
+    readonly type: constants.DECREMENT_ENTHUSIASM;
 }
 
 export type EnthusiasmAction = IncrementEnthusiasm | DecrementEnthusiasm;
@@ -468,10 +468,10 @@ We'll add two optional callback properties to `Props` named `onIncrement` and `o
 
 ```ts
 export interface Props {
-  name: string;
-  enthusiasmLevel?: number;
-  onIncrement?: () => void;
-  onDecrement?: () => void;
+  readonly name: string;
+  readonly enthusiasmLevel?: number;
+  readonly onIncrement?: () => void;
+  readonly onDecrement?: () => void;
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

see https://reactjs.org/docs/components-and-props.html#props-are-read-only