### PR TITLE
Fix incorrect ES6/TS import example

### DIFF
--- a/pages/declaration files/Library Structures.md
+++ b/pages/declaration files/Library Structures.md
@@ -94,7 +94,7 @@ var fs = require("fs");
 In TypeScript or ES6, the `import` keyword serves the same purpose:
 
 ```ts
-import fs = require("fs");
+import * as fs from "fs";
 ```
 
 You'll typically see modular libraries include one of these lines in their documentation:


### PR DESCRIPTION
Corrects an example of ES6 imports that contains invalid syntax and a seemingly-misplaced `require()`.