### PR TITLE
[docs fix] update "Module Resolution Strategies"

### DIFF
--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -46,7 +46,9 @@ Use non-relative paths when importing any of your external dependencies.
 
 There are two possible module resolution strategies: [Node](#node) and [Classic](#classic).
 You can use the `--moduleResolution` flag to specify the module resolution strategy.
-If not specified, the default is [Classic](#classic) for `--module AMD | System | ES2015` or [Node](#node) otherwise.
+If not specified, the default is [Classic](#classic) for `--module es2015` and above (including `esnext`), or [Node](#node) otherwise (including `--module commonjs`). 
+
+> Note: `node` module resolution is now default and recommended. If you are having module resolution problems in TypeScript, try setting `moduleResolution: "node"` to see if it fixes the issue.
 
 ### Classic
 

--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -46,7 +46,7 @@ Use non-relative paths when importing any of your external dependencies.
 
 There are two possible module resolution strategies: [Node](#node) and [Classic](#classic).
 You can use the `--moduleResolution` flag to specify the module resolution strategy.
-If not specified, the default is [Classic](#classic) for `--module es2015` and above (including `esnext`), or [Node](#node) otherwise (including `--module commonjs`). 
+If not specified, the default is [Node](#node) for `--module commonjs`, and [Classic](#classic) otherwise (including when `--module` is set to `amd`, `system`, `umd`, `es2015`, `esnext`, etc.). 
 
 > Note: `node` module resolution is now default and recommended. If you are having module resolution problems in TypeScript, try setting `moduleResolution: "node"` to see if it fixes the issue.
 

--- a/pages/Module Resolution.md
+++ b/pages/Module Resolution.md
@@ -48,7 +48,8 @@ There are two possible module resolution strategies: [Node](#node) and [Classic]
 You can use the `--moduleResolution` flag to specify the module resolution strategy.
 If not specified, the default is [Node](#node) for `--module commonjs`, and [Classic](#classic) otherwise (including when `--module` is set to `amd`, `system`, `umd`, `es2015`, `esnext`, etc.). 
 
-> Note: `node` module resolution is now default and recommended. If you are having module resolution problems in TypeScript, try setting `moduleResolution: "node"` to see if it fixes the issue.
+> Note: `node` module resolution is the most-commonly used in the TypeScript community and is recommended for most projects.
+> If you are having resolution problems with `import`s and `export`s in TypeScript, try setting `moduleResolution: "node"` to see if it fixes the issue.
 
 ### Classic
 


### PR DESCRIPTION
update "Module Resolution Strategies" to reflect how TS actually works


Partially addresses https://github.com/microsoft/TypeScript/issues/39555#issuecomment-656994164


cc @DanielRosenwasser and @orta, the more i look at [the source code for this behavior](https://github.com/microsoft/TypeScript/blob/7c99086eb86eed1570842cd3ad382f2745841072/src/compiler/utilities.ts#L5850-L5856) the more it feels like this cannot be what is intended given our strong preference for `node` style resolution instead of `classic`. then again, I don't really know what went into writing that code. 

but it *looks* wrong at first glance, bc it appears to opt in all ES20XX targets into `classic` module resolution... which doesnt seem like what we want??